### PR TITLE
Allow hierarchy analysis event numbers to be set by the input file

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,25 @@ using the PFOs stored in Pandora's `RecreatedPfos` list along with the list of h
 hierarchy tools can only use the 2D views). The hierarchy building and matching requires minimum quality selection criteria,
 removes neutrons and folds all of the hierarchy to start from the initial neutrino primaries.
 
+The hierarchy analysis algorithm sets the event number by incrementing the number of times the `Run()` function is called
+(0 to N-1 for N events). If the `-e` input file contains event numbers that are not contiguous, then the following xml
+parameter settings (which must be added to the previous ones) need to be included to set the event numbers correctly:
+
+```xml
+    <algorithm type = "LArHierarchyAnalysis">
+        <EventFileName>EventFile.root</EventFileName>
+        <EventTreeName>events</EventTreeName>
+        <EventLeafName>event</EventLeafName>
+        <EventsToSkip>0</EventsToSkip>
+    </algorithm>
+```
+
+Here, `EventFileName` needs to match the input file name specified by the `-e` run parameter, `EventTreeName` defines what TTree
+contains the event numbers (which defaults to `events`) and `EventLeafName` defines the name of the event number variable
+(which defaults to `event`). This workaround is needed since it is currently not possible to pass event (and run) number information
+between Pandora algorithms. By default, no events are skipped, but if the `-s` run option is used, then `EventsToSkip` must be equal
+to this integer to ensure that the correct event numbers are found.
+
 The xml settings files [PandoraSettings_LArRecoND_ThreeD.xml](settings/PandoraSettings_LArRecoND_ThreeD.xml) and
 [PandoraSettings_LArRecoND_ThreeD_DLVtx.xml](settings/PandoraSettings_LArRecoND_ThreeD_DLVtx.xml) contain
 (commented out) examples of using LArContent's

--- a/include/HierarchyAnalysisAlgorithm.h
+++ b/include/HierarchyAnalysisAlgorithm.h
@@ -15,6 +15,9 @@
 
 #include "larpandoracontent/LArHelpers/LArHierarchyHelper.h"
 
+class TFile;
+class TTree;
+
 namespace lar_content
 {
 
@@ -61,6 +64,12 @@ private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     /**
+     *  @brief  Set the event number
+     *
+     */
+    void SetEventNumber();
+
+    /**
      *  @brief  Create the analysis output using hierarchy tools
      *
      *  @param  matchInfo The object containing the reco and MC hierarchies
@@ -89,7 +98,14 @@ private:
     const RecoMCMatch GetRecoMCMatch(const LArHierarchyHelper::RecoHierarchy::Node *pRecoNode,
         const LArHierarchyHelper::MatchInfo &matchInfo, pandora::MCParticleList &rootMCParticles) const;
 
-    int m_event;                       ///< The current event
+    int m_count;                       ///< The number of times the Run() function has been called
+    int m_event;                       ///< The actual event number
+    std::string m_eventFileName;       ///< Name of the ROOT TFile containing the event numbers
+    std::string m_eventTreeName;       ///< Name of the ROOT TTree containing the event numbers
+    std::string m_eventLeafName;       ///< Name of the event number leaf/variable
+    int m_eventsToSkip;                ///< The number of events to skip (from the start of the event file)
+    TFile *m_eventFile;                ///< The ROOT event file pointer
+    TTree *m_eventTree;                ///< The ROOT event tree pointer
     std::string m_caloHitListName;     ///< Name of input calo hit list
     std::string m_pfoListName;         ///< Name of input PFO list
     std::string m_analysisFileName;    ///< The name of the analysis ROOT file to write

--- a/settings/PandoraSettings_LArRecoND_ThreeD.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD.xml
@@ -47,6 +47,12 @@
     </algorithm>
 
     <algorithm type = "LArHierarchyAnalysis">
+        <!-- Enable the following if the input file has event numbers that are not contiguous from 0 to N-1
+        <EventFileName>EventFile.root</EventFileName>
+	<EventTreeName>events</EventTreeName>
+	<EventLeafName>event</EventLeafName>
+	<EventsToSkip>0</EventsToSkip>
+        -->
 	<CaloHitListName>CaloHitList2D</CaloHitListName>
 	<PfoListName>RecreatedPfos</PfoListName>
         <AnalysisFileName>LArRecoND.root</AnalysisFileName>

--- a/settings/PandoraSettings_LArRecoND_ThreeD_DLVtx.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD_DLVtx.xml
@@ -48,6 +48,12 @@
     </algorithm>
 
     <algorithm type = "LArHierarchyAnalysis">
+        <!-- Enable the following if the input file has event numbers that are not contiguous from 0 to N-1
+        <EventFileName>EventFile.root</EventFileName>
+	<EventTreeName>events</EventTreeName>
+	<EventLeafName>event</EventLeafName>
+	<EventsToSkip>0</EventsToSkip>
+        -->
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <PfoListName>RecreatedPfos</PfoListName>
         <AnalysisFileName>LArRecoND.root</AnalysisFileName>


### PR DESCRIPTION
There are occasions when the input ROOT file (specified by the `-e` run parameter) containing the hits has event numbers that are not contiguous. For example, the input file has 10 entries, but instead of the event number going from 0 to 9, it can be 0 to 15 where integers are skipped.

Since it is currently not possible to pass event (and run) numbers between Pandora algorithms, a workaround has been implemented here where we reuse the input ROOT file inside the hierarchy algorithm to get the correct event numbers:

```
   <algorithm type = "LArHierarchyAnalysis">
        <EventFileName>EventFile.root</EventFileName>
        <EventTreeName>events</EventTreeName>
        <EventLeafName>event</EventLeafName>
        <EventsToSkip>0</EventsToSkip>
    </algorithm>
```


If no event file is given, then the event numbers are set to just be the number of times the algorithm is run (once per event).