### PR TITLE
Prevent bug over-running segment indices in flow converter

### DIFF
--- a/ndlarflow/h5_to_root_ndlarflow.py
+++ b/ndlarflow/h5_to_root_ndlarflow.py
@@ -458,9 +458,10 @@ def find_tracks_in_calib_hits(hit_num, flow_out, typ="final"):
     pdg_id=[]
     total = 0.
     # Get fraction information and track information from hit
-    i=0 
+    i=0
+    segments = flow_out["mc_truth/segments/data"]
     while i<len(fracFromHits):
-        if (segIDsFromHits[i]>len(flow_out["mc_truth/segments/data"])):
+        if (segIDsFromHits[i]>=len(segments)):
             i=1+i
             continue
         fracs=fracFromHits[i]


### PR DESCRIPTION
Changes last week to converter script led to index on segment building over-running end of the array for some events. This resolves that.

This definitely prevents the crash and doesn't seem to cause any significant output changes, but I'd like someone else to take a look at it please.