### PR TITLE
Minor changes to h5 converter

### DIFF
--- a/ndlarflow/h5_to_root_ndlarflow.py
+++ b/ndlarflow/h5_to_root_ndlarflow.py
@@ -547,6 +547,10 @@ def find_tracks_in_packet(hit_num, flow_out):
     # Get fraction information and track information from hit
     trajFromHits=flow_out["charge/calib_prompt_hits","charge/packets","mc_truth/segments",hit_num][0][0]
     fracFromHits=flow_out["charge/calib_prompt_hits","charge/packets","mc_truth/packet_fraction",hit_num][0][0]
+    # For whatever reason, we sometimes get masked data in trajFromHits, so
+    # filter it out (we have to access some column, e.g. segment_id, to
+    # "collapse" the mask)
+    trajFromHits=trajFromHits.data[~trajFromHits['segment_id'].mask]
     for fracs in fracFromHits["fraction"][0]:
         total += fracs
         # get fraction information

--- a/ndlarflow/h5_to_root_ndlarflow.py
+++ b/ndlarflow/h5_to_root_ndlarflow.py
@@ -280,7 +280,7 @@ def main(argv=None):
             # Get event info for data
             event = f["charge/events/data"][ev_index]
             event_calib_prompt_hits=flow_out["charge/events/","charge/calib_prompt_hits", events["id"][ev_index]]
-            event_calib_final_hits=flow_out["charge/events/","charge/calib_final_hits", events["id"][ev_index]]
+            # event_calib_final_hits=flow_out["charge/events/","charge/calib_final_hits", events["id"][ev_index]]
             # fill event info
             eventID[0]= event['id']
             event_start_t[0] =int(event["ts_start"])


### PR DESCRIPTION
This fixes a couple of crashes I ran into when running on MiniRun6.1 files:

- These files don't have the `calib_final_hits` dataset, and since the script doesn't currently use it, I commented out the line that loads it. 
- The backtracked segments/fractions are returned from h5flow as masked arrays, and for reasons unknown to me, sometimes there are in fact masked values in those arrays, causing a crash when the output from `find_tracks_in_packet` is later iterated over. So I do the manual equivalent of `np.ma.masked_array.compressed` (which apparently doesn't work when you have a compound dtype).