### PR TITLE
Allow limiting the maximum number of hits for SP(MC) events

### DIFF
--- a/settings/PandoraSettings_LArRecoND_ThreeD.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD.xml
@@ -78,7 +78,7 @@
 	<SelectRecoHits>true</SelectRecoHits>
     </algorithm>
 
-<!-- LArContent hierarchy tools MC and event-level information
+<!-- LArContent hierarchy tools MC and event-level information-->
     <algorithm type = "LArHierarchyValidation">
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <PfoListName>RecreatedPfos</PfoListName>
@@ -100,7 +100,6 @@
         <RemoveRecoNeutrons>true</RemoveRecoNeutrons>
 	<SelectRecoHits>true</SelectRecoHits>
     </algorithm>
--->
 
 <!-- Use old single neutrino event validation
     <algorithm type = "LArNeutrinoEventValidation">

--- a/settings/PandoraSettings_LArRecoND_ThreeD_DLVtx.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD_DLVtx.xml
@@ -79,7 +79,7 @@
 	<SelectRecoHits>true</SelectRecoHits>
     </algorithm>
 
-<!-- LArContent hierarchy tools MC and event-level information
+<!-- LArContent hierarchy tools MC and event-level information-->
     <algorithm type = "LArHierarchyValidation">
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <PfoListName>RecreatedPfos</PfoListName>
@@ -101,7 +101,6 @@
         <RemoveRecoNeutrons>true</RemoveRecoNeutrons>
 	<SelectRecoHits>true</SelectRecoHits>
     </algorithm>
--->
 
 <!-- Use old single neutrino event validation
     <algorithm type = "LArNeutrinoEventValidation">

--- a/settings/PandoraSettings_LArRecoND_ThreeD_Merged.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD_Merged.xml
@@ -73,7 +73,7 @@
         <RemoveRecoNeutrons>true</RemoveRecoNeutrons>
     </algorithm>
 
-<!-- LArContent hierarchy tools MC and event-level information
+<!-- LArContent hierarchy tools MC and event-level information-->
     <algorithm type = "LArHierarchyValidation">
         <Detector>dune_nd</Detector>
         <ValidateMC>true</ValidateMC>
@@ -93,7 +93,6 @@
         <RemoveRecoNeutrons>true</RemoveRecoNeutrons>
 	<SelectRecoHits>true</SelectRecoHits>
     </algorithm>
--->
 
 <!-- Use old single neutrino event validation
     <algorithm type = "LArNeutrinoEventValidation">

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -341,6 +341,14 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
 
         ndsptree->GetEntry(iEvt);
 
+	// Stop processing the event if we have too many space points: reco takes too long
+	const int nSP = larsp->m_x->size();
+	if (parameters.m_maxMergedVoxels > 0 && nSP > parameters.m_maxMergedVoxels)
+        {
+	    std::cout << "SKIPPING EVENT: number of space points " << nSP << " > " << parameters.m_maxMergedVoxels << std::endl;
+	    continue;
+	}
+
         // Some truth information first
         if (parameters.m_dataFormat == Parameters::LArNDFormat::SPMC)
         {
@@ -351,7 +359,7 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
         int hitCounter(0);
 
         // Loop over the space points and make them into caloHits
-        for (size_t isp = 0; isp < larsp->m_x->size(); ++isp)
+        for (size_t isp = 0; isp < nSP; ++isp)
         {
             const float voxelX = (*larsp->m_x)[isp];
             const float voxelY = (*larsp->m_y)[isp];
@@ -1858,7 +1866,7 @@ bool PrintOptions()
               << "    -p                     (optional) [Print status]" << std::endl
               << "    -N                     (optional) [Print event numbers]" << std::endl
               << "    -w width               (optional) [Voxel bin width (cm), default = 0.4 cm]" << std::endl
-              << "    -m maxMergedVoxels     (optional) [Skip events that have N(merged voxels) > maxMergedVoxels (default = no events skipped)]"
+              << "    -m maxMergedVoxels     (optional) [Skip events that have N(space points) or N(merged voxels) > maxMergedVoxels (default = no events skipped)]"
               << std::endl
               << "    -c minMipEquivE        (optional) [Minimum MIP equivalent energy, default = 0.3]" << std::endl
               << std::endl;


### PR DESCRIPTION
Allow the optional `-m` maximum number of hits run parameter to be used for the Space Point format. Events that have more hits will be skipped. This is a workaround to avoid the reconstruction taking too long for 2x2 events containing more than ~10k hits in production jobs. This is disabled by default; initially set to -1, which means it is ignored and all events with any number of hits are processed.

Also turn on the hierarchy validation algorithm from LArContent for various xml run settings, which is useful for MC/reco efficiency studies.