### PR TITLE
Fix MCId map segfault when filling in the hierarchy output for data

### DIFF
--- a/include/HierarchyAnalysisAlgorithm.h
+++ b/include/HierarchyAnalysisAlgorithm.h
@@ -139,6 +139,8 @@ private:
     unsigned int m_minRecoGoodViews;   ///< Minimum number of reconstructed primary good views
     bool m_removeRecoNeutrons;         ///< Whether to remove reconstructed neutrons and their downstream particles
     bool m_selectRecoHits;             ///< Whether to select reco hits that overlap with the MC particle hits
+    bool m_storeClusterRecoHits;       ///< Whether to store all of the hits for each reconstructed PFO cluster
+    bool m_gotMCEventInput;            ///< Boolean to specify if the input event file corresponds to MC
     MCIdUniqueLocalMap m_mcIdMap;      ///< The map of unique-local MCParticle Ids for the given event
 };
 

--- a/include/PandoraInterface.h
+++ b/include/PandoraInterface.h
@@ -88,6 +88,7 @@ public:
 
     int m_nEventsToSkip;       ///< The number of events to skip
     int m_maxMergedVoxels;     ///< The max number of merged voxels to process (default all)
+    int m_minNSpacePoints;     ///< The minimum number of space points for processing an event (default = 2)
     float m_minVoxelMipEquivE; ///< The minimum required voxel equivalent MIP energy (default = 0.3)
 
     bool m_use3D;     ///< Create 3D LArCaloHits
@@ -126,6 +127,7 @@ inline Parameters::Parameters() :
     m_printOverallRecoStatus(false),
     m_nEventsToSkip(0),
     m_maxMergedVoxels(-1),
+    m_minNSpacePoints(2),
     m_minVoxelMipEquivE(0.3f),
     m_use3D(true),
     m_useLArTPC(true),

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -348,6 +348,13 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
 	    std::cout << "SKIPPING EVENT: number of space points " << nSP << " > " << parameters.m_maxMergedVoxels << std::endl;
 	    continue;
 	}
+	// Also stop processing the event if it has less than 2 hits (to match the H5-to-ROOT script logic).
+	// It has a single trigger ntuple entry but the event is empty, so we can't make CaloHits
+	if (nSP < 2)
+	{
+	    std::cout << "SKIPPING EVENT: number of space points " << nSP << " < 2" << std::endl;
+	    continue;
+	}
 
         // Some truth information first
         if (parameters.m_dataFormat == Parameters::LArNDFormat::SPMC)

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -341,20 +341,19 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
 
         ndsptree->GetEntry(iEvt);
 
-	// Stop processing the event if we have too many space points: reco takes too long
-	const int nSP = larsp->m_x->size();
-	if (parameters.m_maxMergedVoxels > 0 && nSP > parameters.m_maxMergedVoxels)
+        // Stop processing the event if we have too many space points: reco takes too long
+        const int nSP = larsp->m_x->size();
+        if (parameters.m_maxMergedVoxels > 0 && nSP > parameters.m_maxMergedVoxels)
         {
-	    std::cout << "SKIPPING EVENT: number of space points " << nSP << " > " << parameters.m_maxMergedVoxels << std::endl;
-	    continue;
-	}
-	// Also stop processing the event if it has less than 2 hits (to match the H5-to-ROOT script logic).
-	// It has a single trigger ntuple entry but the event is empty, so we can't make CaloHits
-	if (nSP < 2)
-	{
-	    std::cout << "SKIPPING EVENT: number of space points " << nSP << " < 2" << std::endl;
-	    continue;
-	}
+            std::cout << "SKIPPING EVENT: number of space points " << nSP << " > " << parameters.m_maxMergedVoxels << std::endl;
+            continue;
+        }
+        // Also stop processing the event if it has too few hits (we can't make CaloHits for essentially empty events)
+        if (nSP < parameters.m_minNSpacePoints)
+        {
+            std::cout << "SKIPPING EVENT: number of space points " << nSP << " < " << parameters.m_minNSpacePoints << std::endl;
+            continue;
+        }
 
         // Some truth information first
         if (parameters.m_dataFormat == Parameters::LArNDFormat::SPMC)
@@ -418,8 +417,8 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
                 LArSPMC *larspmc = dynamic_cast<LArSPMC *>(larsp.get());
                 const std::vector<float> mcContribs = (*larspmc->m_hit_packetFrac)[isp];
                 const int biggestContribIndex = std::distance(mcContribs.begin(), std::max_element(mcContribs.begin(), mcContribs.end()));
-		const std::vector<long> hitPartIDVect = (*larspmc->m_hit_particleID)[isp];
-		trackID = (hitPartIDVect.size() > biggestContribIndex) ? hitPartIDVect[biggestContribIndex] : 0;
+                const std::vector<long> hitPartIDVect = (*larspmc->m_hit_particleID)[isp];
+                trackID = (hitPartIDVect.size() > biggestContribIndex) ? hitPartIDVect[biggestContribIndex] : 0;
 
                 // Due to the merging of hits, the contributions can sometimes add up to more than 1.
                 // Normalise first
@@ -1773,7 +1772,7 @@ bool ParseCommandLine(int argc, char *argv[], Parameters &parameters)
     std::string geomVolName("");
     std::string sensDetName("");
 
-    while ((cOpt = getopt(argc, argv, "r:i:e:k:f:g:t:v:d:n:s:j:w:m:c:MpNh")) != -1)
+    while ((cOpt = getopt(argc, argv, "r:i:e:k:f:g:t:v:d:n:s:j:w:m:b:c:MpNh")) != -1)
     {
         switch (cOpt)
         {
@@ -1825,6 +1824,9 @@ bool ParseCommandLine(int argc, char *argv[], Parameters &parameters)
             case 'm':
                 parameters.m_maxMergedVoxels = atoi(optarg);
                 break;
+            case 'b':
+                parameters.m_minNSpacePoints = atoi(optarg);
+                break;
             case 'c':
                 parameters.m_minVoxelMipEquivE = atof(optarg);
                 break;
@@ -1875,6 +1877,7 @@ bool PrintOptions()
               << "    -w width               (optional) [Voxel bin width (cm), default = 0.4 cm]" << std::endl
               << "    -m maxMergedVoxels     (optional) [Skip events that have N(space points) or N(merged voxels) > maxMergedVoxels (default = no events skipped)]"
               << std::endl
+              << "    -b minNSpacePoints     (optional) [Skip events that have N(space points) < minNSpacePoints (default < 2)]" << std::endl
               << "    -c minMipEquivE        (optional) [Minimum MIP equivalent energy, default = 0.3]" << std::endl
               << std::endl;
 


### PR DESCRIPTION
Check that the input file is MC before filling the MCId map that is used for the hierarchy output. This avoids a map segfault and missing ROOT branch warnings when running on data input files. 

Also added the "StoreClusterRecoHits" xml parameter (default = true) to specify if the reco hits should be stored in the ROOT output.