### PR TITLE
Update to trigger ID handling and behaviour for low or no hit events

### DIFF
--- a/ndlarflow/h5_to_root_ndlarflow.py
+++ b/ndlarflow/h5_to_root_ndlarflow.py
@@ -142,7 +142,9 @@ def main(argv=None):
             runID = np.array( [0], dtype='int32' )
             subrunID = np.array( [0], dtype='int32' )
             eventID = np.array( [event['id']], dtype='int32' )
-            if badEvt==False:
+            triggerID = np.array( [triggerIDs[ievt]], dtype='int32')
+
+            if triggerID!=((1 << 31)-1):
                 event_start_t = np.array( [event['ts_start']], dtype='int32' )
                 event_end_t = np.array( [event['ts_end']], dtype='int32' )
                 event_unix_ts = np.array( [event['unix_ts']], dtype='int32' )
@@ -150,9 +152,6 @@ def main(argv=None):
                 event_start_t = np.array( [-5], dtype='int32' )
                 event_end_t = np.array( [-5], dtype='int32' )
                 event_unix_ts = np.array( [-5], dtype='int32' )
-
-            triggerID = np.array( [triggerIDs[ievt]], dtype='int32')
-
 
             # "uncalib" -- this alternative is not currently used in LArPandora that I can tell, so no need to save. Making optional to use the prompt or final hits to be saved.
             #######################################

--- a/ndlarflow/h5_to_root_ndlarflow.py
+++ b/ndlarflow/h5_to_root_ndlarflow.py
@@ -175,6 +175,7 @@ def main(argv=None):
                     particleIDLocal = trajFromHits['traj_id'].astype('int64')
                     interactionIndex = trajFromHits['vertex_id'].astype('int64')
                 else:
+                    matches = np.array( [0] ).astype('float32')
                     packetFrac = np.array( [] ).astype('float32')
                     pdgHit = np.array( [] ).astype('int32')
                     trackID = np.array( [] ).astype('int32')

--- a/ndlarflow/h5_to_root_ndlarflow.py
+++ b/ndlarflow/h5_to_root_ndlarflow.py
@@ -159,42 +159,68 @@ def main(argv=None):
             if useData==False:
                 # Truth-level info for hits
                 #######################################
-                trajFromHits=flow_out["charge/calib_prompt_hits","charge/packets","mc_truth/segments",hits_ids[:]][:,0]
-                fracFromHits=flow_out["charge/calib_prompt_hits","charge/packets","mc_truth/packet_fraction",hits_ids[:]][:,0]
+                if badEvt==False:
+                    trajFromHits=flow_out["charge/calib_prompt_hits","charge/packets","mc_truth/segments",hits_ids[:]][:,0]
+                    fracFromHits=flow_out["charge/calib_prompt_hits","charge/packets","mc_truth/packet_fraction",hits_ids[:]][:,0]
 
-                matches = trajFromHits['segment_id'].count(axis=1).astype('uint16')
+                    matches = trajFromHits['segment_id'].count(axis=1).astype('uint16')
 
-                packetFrac = np.array( awk.flatten( awk.flatten( awk.Array( fracFromHits['fraction'].astype('float32') ) ) ) )
-                packetFrac = packetFrac[np.where(packetFrac!=0)]
+                    packetFrac = np.array( awk.flatten( awk.flatten( awk.Array( fracFromHits['fraction'].astype('float32') ) ) ) )
+                    packetFrac = packetFrac[np.where(packetFrac!=0)]
 
-                trajFromHits=trajFromHits.data[~trajFromHits['segment_id'].mask]
-                pdgHit = trajFromHits['pdg_id'].astype('int32')
-                trackID = trajFromHits['segment_id'].astype('int32')
-                particleID = trajFromHits['file_traj_id'].astype('int64')
-                particleIDLocal = trajFromHits['traj_id'].astype('int64')
-                interactionIndex = trajFromHits['vertex_id'].astype('int64')
+                    trajFromHits=trajFromHits.data[~trajFromHits['segment_id'].mask]
+                    pdgHit = trajFromHits['pdg_id'].astype('int32')
+                    trackID = trajFromHits['segment_id'].astype('int32')
+                    particleID = trajFromHits['file_traj_id'].astype('int64')
+                    particleIDLocal = trajFromHits['traj_id'].astype('int64')
+                    interactionIndex = trajFromHits['vertex_id'].astype('int64')
+                else:
+                    packetFrac = np.array( [] ).astype('float32')
+                    pdgHit = np.array( [] ).astype('int32')
+                    trackID = np.array( [] ).astype('int32')
+                    particleID = np.array( [] ).astype('int64')
+                    particleIDLocal = np.array( [] ).astype('int64')
+                    interactionIndex = np.array( [] ).astype('int64')
 
                 # Truth-level info for the spill
                 #######################################
-                spillID=flow_out["charge/calib_prompt_hits","charge/packets","mc_truth/segments",hits_ids]["event_id"][0][0][0]
-                # Trajectories
-                traj_indicesArray = np.where(flow_out['mc_truth/trajectories/data']["event_id"] == spillID)[0]
-                traj = flow_out["mc_truth/trajectories/data"][traj_indicesArray]
-                trajStartX = (traj['xyz_start'][:,0]).astype('float32')
-                trajStartY = (traj['xyz_start'][:,1]).astype('float32')
-                trajStartZ = (traj['xyz_start'][:,2]).astype('float32')
-                trajEndX = (traj['xyz_end'][:,0]).astype('float32')
-                trajEndY = (traj['xyz_end'][:,1]).astype('float32')
-                trajEndZ = (traj['xyz_end'][:,2]).astype('float32')
-                trajID = (traj['file_traj_id']).astype('int64')
-                trajIDLocal = (traj['traj_id']).astype('int64')
-                trajPDG = (traj['pdg_id']).astype('int32')
-                trajE = (traj['E_start']*MeV2GeV).astype('float32')
-                trajPx = (traj['pxyz_start'][:,0]*MeV2GeV).astype('float32')
-                trajPy = (traj['pxyz_start'][:,1]*MeV2GeV).astype('float32')
-                trajPz = (traj['pxyz_start'][:,2]*MeV2GeV).astype('float32')
-                trajVertexID = (traj['vertex_id']).astype('int64')
-                trajParentID = (traj['parent_id']).astype('int64')
+                if badEvt==False:
+                    spillID=flow_out["charge/calib_prompt_hits","charge/packets","mc_truth/segments",hits_ids]["event_id"][0][0][0]
+                    # Trajectories
+                    traj_indicesArray = np.where(flow_out['mc_truth/trajectories/data']["event_id"] == spillID)[0]
+                    traj = flow_out["mc_truth/trajectories/data"][traj_indicesArray]
+                    trajStartX = (traj['xyz_start'][:,0]).astype('float32')
+                    trajStartY = (traj['xyz_start'][:,1]).astype('float32')
+                    trajStartZ = (traj['xyz_start'][:,2]).astype('float32')
+                    trajEndX = (traj['xyz_end'][:,0]).astype('float32')
+                    trajEndY = (traj['xyz_end'][:,1]).astype('float32')
+                    trajEndZ = (traj['xyz_end'][:,2]).astype('float32')
+                    trajID = (traj['file_traj_id']).astype('int64')
+                    trajIDLocal = (traj['traj_id']).astype('int64')
+                    trajPDG = (traj['pdg_id']).astype('int32')
+                    trajE = (traj['E_start']*MeV2GeV).astype('float32')
+                    trajPx = (traj['pxyz_start'][:,0]*MeV2GeV).astype('float32')
+                    trajPy = (traj['pxyz_start'][:,1]*MeV2GeV).astype('float32')
+                    trajPz = (traj['pxyz_start'][:,2]*MeV2GeV).astype('float32')
+                    trajVertexID = (traj['vertex_id']).astype('int64')
+                    trajParentID = (traj['parent_id']).astype('int64')
+                else:
+                    trajStartX = np.array( [] ).astype('float32')
+                    trajStartY = np.array( [] ).astype('float32')
+                    trajStartZ = np.array( [] ).astype('float32')
+                    trajEndX = np.array( [] ).astype('float32')
+                    trajEndY = np.array( [] ).astype('float32')
+                    trajEndZ = np.array( [] ).astype('float32')
+                    trajID = np.array( [] ).astype('int64')
+                    trajIDLocal = np.array( [] ).astype('int64')
+                    trajPDG = np.array( [] ).astype('int32')
+                    trajE = np.array( [] ).astype('float32')
+                    trajPx = np.array( [] ).astype('float32')
+                    trajPy = np.array( [] ).astype('float32')
+                    trajPz = np.array( [] ).astype('float32')
+                    trajVertexID = np.array( [] ).astype('int64')
+                    trajParentID = np.array( [] ).astype('int64')
+
                 # Vertices
                 vertex_indicesArray = np.where(flow_out["/mc_truth/interactions/data"]["event_id"] == spillID)[0]
                 vtx = flow_out["/mc_truth/interactions/data"][vertex_indicesArray]

--- a/ndlarflow/h5_to_root_ndlarflow.py
+++ b/ndlarflow/h5_to_root_ndlarflow.py
@@ -87,20 +87,17 @@ def main(argv=None):
         eventsToRun=len(events)
 
         # Get the array of the trigger type for every event in the file
-        if useData==True:
-            triggerIDsData=flow_out["charge/events","charge/ext_trigs",events["id"][:]]
-            triggerIDsAll=np.array(np.ma.getdata(triggerIDsData["iogroup"]),dtype='int32')
+        triggerIDsData=flow_out["charge/events","charge/ext_trigs",events["id"][:]]
+        triggerIDsAll=np.array(np.ma.getdata(triggerIDsData["iogroup"]),dtype='int32')
 
-            triggerIDs = np.array( np.broadcast_to( (1 << 31) - 1, shape=eventsToRun ) )
-            for i in range(len(triggerIDsAll)):
-                if np.sum(triggerIDsAll[i])==0:
-                    continue
-                if 5 in triggerIDsAll[i]:
-                    triggerIDs[i] = 5
-                else:
-                    triggerIDs[i] = triggerIDsAll[i][0]
-        else:
-            triggerIDs = np.zeros( eventsToRun, dtype='int32' )
+        triggerIDs = np.array( np.broadcast_to( (1 << 31) - 1, shape=eventsToRun ) )
+        for i in range(len(triggerIDsAll)):
+            if np.sum(triggerIDsAll[i])==0:
+                continue
+            if 5 in triggerIDsAll[i]:
+                triggerIDs[i] = 5
+            else:
+                triggerIDs[i] = triggerIDsAll[i][0]
 
         for ievt in range(eventsToRun):
             badEvt=False

--- a/ndlarflow/rootToRootConversion.C
+++ b/ndlarflow/rootToRootConversion.C
@@ -264,7 +264,6 @@ void rootToRootConversion(
     std::vector<float> all_hit_packetFrac;
 
     for (unsigned int idx=0; idx<=NEvents; ++idx) {
-        if ( idx%100==0 ) std::cout << in_run << ":" << in_subrun << ":" << in_event << ":" << in_subevent << std::endl;
         if (idx!=NEvents){
             tr->GetEntry(idx);
         }
@@ -274,6 +273,7 @@ void rootToRootConversion(
             thisEvent = in_event;
 	    
 	}
+	if ( idx%100==0 ) std::cout << in_run << ":" << in_subrun << ":" << in_event << ":" << in_subevent << std::endl;
         if ( idx > 0 && ( (in_run!=thisRun || in_subrun!=thisSubRun || in_event!=thisEvent) || idx==NEvents ) ) {
             if ( isMC ) {
                 // Something has changed... finish with the matches, fill the tree, and reset


### PR DESCRIPTION
An updated version for folks to start looking at. I tested that it runs the Python portion and gives sensible answers, however I still need to test the root to root conversion.

**Big big notes:**

* This updates to favour 5 over 6 where both are present, to give int32 max if no trigger is present (following a comment in my thread with Sindhu and co. noting that  1 << 31 - 1 is for things that have no external trigger (or I should say, in our case where our returned trigger array comes up with all 0 entries, which I think is what that corresponds to), and to otherwise return the first entry of the trigger array.
* The implementation here is going to be different than SPINE's but meant to provide the same end result, so I think we can just check with them or ask Noë or someone else to check the trigger matching to ensure that our final trigger product matches the one they have e.g.
* I think this method as implemented may not be quite what is wanted for FSD, based on Matt's discussion in the group Slack chat I was in. However, since there are no beam triggers where we have to ensure analyzers get the right POT, maybe this can be seen as less concerning. But worth thinking about.

-

* This also updates the behaviour for events with basically no hits: my understanding from the few quick Slack chats is that SPINE happily returns empty events. I think this is probably what you want anyway for the case of triggered events, where there not being info is actually meaningful in itself. So, this PR drastically changes behaviour with empty events. Will be good to have folks thoughts on this.
* I had noticed an event complaining about one of the time variables when not skipping "bad events" so for now just hard code the time for them to be -5. Feel free to suggest other behaviours.

-

* It's interesting that we're explicitly setting run and subrun IDs to 0 -- for data at least, can we not get something like a run and/or subrun number from the data file? 

-

* For MC right now: I have it just return trigger type = 0. Maybe someone knows if that field is actually meant to exist in 2x2 sim however?

-

* I have NOT yet checked the behaviour of some of the MC truth related bits on empty/nearly empty events in sim, e.g. I also have not checked how such empty events are handled in LArRecoND in either data or sim. **This should be part of testing. I can let people know what I see when I run a test.**