### PR TITLE
Add an nhits branch to the output ROOT file, then set up the Hierarch…

### DIFF
--- a/include/HierarchyAnalysisAlgorithm.h
+++ b/include/HierarchyAnalysisAlgorithm.h
@@ -108,6 +108,7 @@ private:
     int m_startTime;                   ///< The event trigger start time (ticks = 0.1 usec)
     int m_endTime;                     ///< The event trigger end time (ticks = 0.1 usec)
     int m_triggers;                    ///< The event trigger flag
+    int m_nhits;                       ///< The event number of hits.
     std::vector<long> *m_mcIDs;        ///< The vector of unique MC particle IDs for the event
     std::vector<long> *m_mcLocalIDs;   ///< The vector of local MC particle IDs for the event
     std::string m_eventFileName;       ///< Name of the ROOT TFile containing the event numbers
@@ -119,9 +120,11 @@ private:
     std::string m_startTimeLeafName;   ///< Name of the event start time leaf/variable
     std::string m_endTimeLeafName;     ///< Name of the event end time leaf/variable
     std::string m_triggersLeafName;    ///< Name of the event triggers leaf/variable
+    std::string m_nhitsLeafName;       ///< Name of the event nhits leaf/variable
     std::string m_mcIdLeafName;        ///< Name of the uniqne MC particle ID leaf/variable
     std::string m_mcLocalIdLeafName;   ///< Name of the local MC particle ID leaf/variable
     int m_eventsToSkip;                ///< The number of events to skip (from the start of the event file)
+    int m_minhitsToSkip;               ///< The number of events where PandoraInterface is being told to skip the event
     TFile *m_eventFile;                ///< The ROOT event file pointer
     TTree *m_eventTree;                ///< The ROOT event tree pointer
     std::string m_caloHitListName;     ///< Name of input calo hit list

--- a/ndlarflow/rootToRootConversion.C
+++ b/ndlarflow/rootToRootConversion.C
@@ -150,7 +150,7 @@ void rootToRootConversion(
     std::cout << "Loaded in tree with " << NEvents << " entries." << std::endl;
 
     // OUTPUT TREE
-    int run, subrun, event, event_start_t, event_end_t, unix_ts;
+    int run, subrun, event, event_start_t, event_end_t, unix_ts, nhits;
     int triggers;
     std::vector<float> x;
     std::vector<float> y;
@@ -207,6 +207,7 @@ void rootToRootConversion(
     outgoingTree->Branch("event_end_t", &event_end_t);
     outgoingTree->Branch("triggers",&triggers);
     outgoingTree->Branch("unix_ts", &unix_ts);
+    outgoingTree->Branch("nhits",&nhits);
     outgoingTree->Branch("x", &x);
     outgoingTree->Branch("y", &y);
     outgoingTree->Branch("z", &z);
@@ -319,6 +320,7 @@ void rootToRootConversion(
                 }
             }
             // Fill
+	    nhits = (int)x.size();
             outgoingTree->Fill();
             // Clear
             triggers=-999;

--- a/settings/PandoraSettings_LArRecoND_ThreeD.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD.xml
@@ -62,6 +62,7 @@
 	<MCIdLeafName>mcp_id</MCIdLeafName>
 	<MCLocalIdLeafName>mcp_idLocal</MCLocalIdLeafName>
 	<EventsToSkip>0</EventsToSkip>
+	<MinHitsToSkip>2</MinHitsToSkip>
 	<CaloHitListName>CaloHitList2D</CaloHitListName>
 	<PfoListName>RecreatedPfos</PfoListName>
         <AnalysisFileName>LArRecoND.root</AnalysisFileName>

--- a/src/HierarchyAnalysisAlgorithm.cc
+++ b/src/HierarchyAnalysisAlgorithm.cc
@@ -30,6 +30,7 @@ HierarchyAnalysisAlgorithm::HierarchyAnalysisAlgorithm() :
     m_startTime{0},
     m_endTime{0},
     m_triggers{0},
+    m_nhits{0},
     m_mcIDs{nullptr},
     m_mcLocalIDs{nullptr},
     m_eventFileName{""},
@@ -41,6 +42,7 @@ HierarchyAnalysisAlgorithm::HierarchyAnalysisAlgorithm() :
     m_startTimeLeafName{"event_start_t"},
     m_endTimeLeafName{"event_end_t"},
     m_triggersLeafName{"triggers"},
+    m_nhitsLeafName{"nhits"},
     m_mcIdLeafName{"mcp_id"},
     m_mcLocalIdLeafName{"mcp_idLocal"},
     m_eventsToSkip{0},
@@ -91,6 +93,13 @@ StatusCode HierarchyAnalysisAlgorithm::Run()
     // Increment the algorithm run count
     ++m_count;
 
+    std::cout << "I think I'm on event " << m_count+m_eventsToSkip << std::endl;
+
+    // Set the event run number and trigger timing info, as well as the unique-local MCParticle Id map
+    this->SetEventRunMCIdInfo();
+
+    std::cout << "I'm actually on event " << m_count+m_eventsToSkip << std::endl;
+
     // Need to use 2D calo hit list for now since LArHierarchyHelper::MCHierarchy::IsReconstructable()
     // checks for minimum number of hits in the U, V & W views only, which will fail for 3D
     const CaloHitList *pCaloHitList(nullptr);
@@ -121,9 +130,6 @@ StatusCode HierarchyAnalysisAlgorithm::Run()
     LArHierarchyHelper::MatchHierarchies(matchInfo);
     matchInfo.Print(mcHierarchy);
 
-    // Set the event run number and trigger timing info, as well as the unique-local MCParticle Id map
-    this->SetEventRunMCIdInfo();
-
     // Analysis PFO & matched reco-MC output
     this->EventAnalysisOutput(matchInfo);
 
@@ -144,6 +150,18 @@ void HierarchyAnalysisAlgorithm::SetEventRunMCIdInfo()
         // Sets m_event, m_run, m_subRun, m_unixTime, m_startTime, m_endTime & m_triggers
         const int iEntry = m_count + m_eventsToSkip;
         m_eventTree->GetEntry(iEntry);
+
+	// Check if we should actually be pointing to a higher event number due to skipping some events in Pandora
+	if ( m_nhits < m_minhitsToSkip ) {
+	  // Skip ahead as many events as we need to
+	  int thisHits = m_nhits;
+	  while ( thisHits < m_minhitsToSkip ) {
+	    m_count+=1;
+	    const int newEntry = m_count + m_eventsToSkip;
+	    m_eventTree->GetEntry(newEntry);
+	    thisHits = m_nhits;
+	  }
+	}
 
         // Fill the Id map
         if (m_gotMCEventInput)
@@ -610,12 +628,16 @@ StatusCode HierarchyAnalysisAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "EndTimeLeafName", m_endTimeLeafName));
     PANDORA_RETURN_RESULT_IF_AND_IF(
         STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TriggersLeafName", m_triggersLeafName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+	STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NHitsLeafName", m_nhitsLeafName));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MCIdLeafName", m_mcIdLeafName));
     PANDORA_RETURN_RESULT_IF_AND_IF(
         STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MCLocalIdLeafName", m_mcLocalIdLeafName));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "EventsToSkip", m_eventsToSkip));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinHitsToSkip", m_minhitsToSkip));
 
     // Setup the event ROOT file
     if (m_eventFileName.size() > 0)
@@ -636,6 +658,7 @@ StatusCode HierarchyAnalysisAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
                 m_eventTree->SetBranchStatus(m_startTimeLeafName.c_str(), 1);
                 m_eventTree->SetBranchStatus(m_endTimeLeafName.c_str(), 1);
                 m_eventTree->SetBranchStatus(m_triggersLeafName.c_str(), 1);
+		m_eventTree->SetBranchStatus(m_nhitsLeafName.c_str(), 1);
                 m_eventTree->SetBranchAddress(m_eventLeafName.c_str(), &m_event);
                 m_eventTree->SetBranchAddress(m_runLeafName.c_str(), &m_run);
                 m_eventTree->SetBranchAddress(m_subRunLeafName.c_str(), &m_subRun);
@@ -643,6 +666,7 @@ StatusCode HierarchyAnalysisAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
                 m_eventTree->SetBranchAddress(m_startTimeLeafName.c_str(), &m_startTime);
                 m_eventTree->SetBranchAddress(m_endTimeLeafName.c_str(), &m_endTime);
                 m_eventTree->SetBranchAddress(m_triggersLeafName.c_str(), &m_triggers);
+		m_eventTree->SetBranchAddress(m_nhitsLeafName.c_str(), &m_nhits);
 
                 // Check if we have MC branches
                 if (m_eventTree->GetBranch(m_mcIdLeafName.c_str()) && m_eventTree->GetBranch(m_mcLocalIdLeafName.c_str()))


### PR DESCRIPTION
…yAnalysis algorithm to read this. If the number of hits is less than a given amount (which can be set from the XML) then skip ahead in the input file. This is because we are skipping events with less than 2 hits in Pandora Interface at the moment and this will keep us in step with that at HierarchyAnalysis when looking at the input file for metadata.

Thanks to Noe for reporting the issue and to all involved in the discussion, especially to Maria Brigida for pointing the right way.

Also note: this is a first pass at a sort of solution, we can tinker further and of course will have to propagate whatever changes to the other LArRecoND XMLs.