### PR TITLE
Add unix_ts_usec for Mx2 matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ IDs for CAF truth matching:
 	<RunLeafName>run</RunLeafName>
 	<SubRunLeafName>subrun</SubRunLeafName>
 	<UnixTimeLeafName>unix_ts</UnixTimeLeafName>
+	<UnixTimeUsecLeafName>unix_ts_usec</UnixTimeUsecLeafName>
 	<StartTimeLeafName>event_start_t</StartTimeLeafName>
 	<EndTimeLeafName>event_end_t</EndTimeLeafName>
         <MCIdLeafName>mcp_id</MCIdLeafName>

--- a/include/HierarchyAnalysisAlgorithm.h
+++ b/include/HierarchyAnalysisAlgorithm.h
@@ -105,6 +105,7 @@ private:
     int m_run;                         ///< The run number
     int m_subRun;                      ///< The subrun number
     int m_unixTime;                    ///< The unix trigger time (seconds)
+    int m_unixTimeUsec;                ///< The unix trigger time (microsecond component)
     int m_startTime;                   ///< The event trigger start time (ticks = 0.1 usec)
     int m_endTime;                     ///< The event trigger end time (ticks = 0.1 usec)
     int m_triggers;                    ///< The event trigger flag
@@ -117,6 +118,7 @@ private:
     std::string m_runLeafName;         ///< Name of the run number leaf/variable
     std::string m_subRunLeafName;      ///< Name of the subrun number leaf/variable
     std::string m_unixTimeLeafName;    ///< Name of the unix time leaf/variable
+    std::string m_unixTimeUsecLeafName;///< Name of the unix time microsecond component leaf/variable
     std::string m_startTimeLeafName;   ///< Name of the event start time leaf/variable
     std::string m_endTimeLeafName;     ///< Name of the event end time leaf/variable
     std::string m_triggersLeafName;    ///< Name of the event triggers leaf/variable

--- a/ndlarflow/h5_to_root_ndlarflow.py
+++ b/ndlarflow/h5_to_root_ndlarflow.py
@@ -150,10 +150,12 @@ def main(argv=None):
                 event_start_t = np.array( [event['ts_start']], dtype='int32' )
                 event_end_t = np.array( [event['ts_end']], dtype='int32' )
                 event_unix_ts = np.array( [event['unix_ts']], dtype='int32' )
+                event_unix_ts_usec = np.array( [event['unix_ts_usec']], dtype='int32' )
             else:
                 event_start_t = np.array( [-5], dtype='int32' )
                 event_end_t = np.array( [-5], dtype='int32' )
                 event_unix_ts = np.array( [-5], dtype='int32' )
+                event_unix_ts_usec = np.array( [-5], dtype='int32' )
 
             # "uncalib" -- this alternative is not currently used in LArPandora that I can tell, so no need to save. Making optional to use the prompt or final hits to be saved.
             #######################################
@@ -256,7 +258,8 @@ def main(argv=None):
                 nu_code = codes
 
             ## Rebuild now with all the individual types
-            event_dict = { 'run':runID, 'subrun':subrunID, 'event':eventID, "triggers":triggerID, 'unix_ts':event_unix_ts, 'event_start_t':event_start_t, 'event_end_t':event_end_t }
+            event_dict = { 'run':runID, 'subrun':subrunID, 'event':eventID, "triggers":triggerID, 'unix_ts':event_unix_ts, 'unix_ts_usec':event_unix_ts_usec,
+                           'event_start_t':event_start_t, 'event_end_t':event_end_t }
 
             if useData==False:
                 other_dict = {  'x':hits_x, 'y':hits_y, 'z':hits_z, 'ts':hits_ts, 'charge':hits_Q, 'E':hits_E, 'matches':matches,\

--- a/ndlarflow/rootToRootConversion.C
+++ b/ndlarflow/rootToRootConversion.C
@@ -29,7 +29,7 @@ void rootToRootConversion(
     const int MaxDepthArrayNu = isMC ? 500 : 1;
 
     // Get the data products FROM the tree
-    int in_run, in_subrun, in_event, in_subevent, in_event_start_t, in_event_end_t, in_unix_ts, in_triggers;
+    int in_run, in_subrun, in_event, in_subevent, in_event_start_t, in_event_end_t, in_unix_ts, in_unix_ts_usec, in_triggers;
 
     // hits
     int Nhits;
@@ -89,6 +89,7 @@ void rootToRootConversion(
     tr->SetBranchAddress("event",&in_event);
     tr->SetBranchAddress("triggers",&in_triggers);
     tr->SetBranchAddress("unix_ts",&in_unix_ts);
+    tr->SetBranchAddress("unix_ts_usec",&in_unix_ts_usec);
     tr->SetBranchAddress("event_start_t",&in_event_start_t);
     tr->SetBranchAddress("event_end_t",&in_event_end_t);
     tr->SetBranchAddress("subevent",&in_subevent);
@@ -150,7 +151,7 @@ void rootToRootConversion(
     std::cout << "Loaded in tree with " << NEvents << " entries." << std::endl;
 
     // OUTPUT TREE
-    int run, subrun, event, event_start_t, event_end_t, unix_ts, nhits;
+    int run, subrun, event, event_start_t, event_end_t, unix_ts, unix_ts_usec, nhits;
     int triggers;
     std::vector<float> x;
     std::vector<float> y;
@@ -207,6 +208,7 @@ void rootToRootConversion(
     outgoingTree->Branch("event_end_t", &event_end_t);
     outgoingTree->Branch("triggers",&triggers);
     outgoingTree->Branch("unix_ts", &unix_ts);
+    outgoingTree->Branch("unix_ts_usec", &unix_ts_usec);
     outgoingTree->Branch("nhits",&nhits);
     outgoingTree->Branch("x", &x);
     outgoingTree->Branch("y", &y);
@@ -409,6 +411,7 @@ void rootToRootConversion(
         event_start_t = in_event_start_t;
         event_end_t = in_event_end_t;
         unix_ts = in_unix_ts;
+        unix_ts_usec = in_unix_ts_usec;
         triggers = in_triggers;
 	
         // fill up the vectors for as much stuff as we can in this subevent:

--- a/settings/PandoraSettings_LArRecoND_ThreeD.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD.xml
@@ -57,6 +57,7 @@
 	<RunLeafName>run</RunLeafName>
 	<SubRunLeafName>subrun</SubRunLeafName>
 	<UnixTimeLeafName>unix_ts</UnixTimeLeafName>
+	<UnixTimeUsecLeafName>unix_ts_usec</UnixTimeUsecLeafName>
 	<StartTimeLeafName>event_start_t</StartTimeLeafName>
 	<EndTimeLeafName>event_end_t</EndTimeLeafName>
 	<MCIdLeafName>mcp_id</MCIdLeafName>

--- a/settings/PandoraSettings_LArRecoND_ThreeD_DLVtx.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD_DLVtx.xml
@@ -58,6 +58,7 @@
 	<RunLeafName>run</RunLeafName>
 	<SubRunLeafName>subrun</SubRunLeafName>
 	<UnixTimeLeafName>unix_ts</UnixTimeLeafName>
+	<UnixTimeUsecLeafName>unix_ts_usec</UnixTimeUsecLeafName>
 	<StartTimeLeafName>event_start_t</StartTimeLeafName>
 	<EndTimeLeafName>event_end_t</EndTimeLeafName>
 	<MCIdLeafName>mcp_id</MCIdLeafName>

--- a/settings/PandoraSettings_LArRecoND_ThreeD_Merged.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD_Merged.xml
@@ -53,6 +53,7 @@
 	<RunLeafName>run</RunLeafName>
 	<SubRunLeafName>subrun</SubRunLeafName>
 	<UnixTimeLeafName>unix_ts</UnixTimeLeafName>
+	<UnixTimeUsecLeafName>unix_ts_usec</UnixTimeUsecLeafName>
 	<StartTimeLeafName>event_start_t</StartTimeLeafName>
 	<EndTimeLeafName>event_end_t</EndTimeLeafName>
 	<MCIdLeafName>mcp_id</MCIdLeafName>

--- a/src/HierarchyAnalysisAlgorithm.cc
+++ b/src/HierarchyAnalysisAlgorithm.cc
@@ -27,6 +27,7 @@ HierarchyAnalysisAlgorithm::HierarchyAnalysisAlgorithm() :
     m_run{0},
     m_subRun{0},
     m_unixTime{0},
+    m_unixTimeUsec{0},
     m_startTime{0},
     m_endTime{0},
     m_triggers{0},
@@ -39,6 +40,7 @@ HierarchyAnalysisAlgorithm::HierarchyAnalysisAlgorithm() :
     m_runLeafName{"run"},
     m_subRunLeafName{"subrun"},
     m_unixTimeLeafName{"unix_ts"},
+    m_unixTimeUsecLeafName{"unix_ts_usec"},
     m_startTimeLeafName{"event_start_t"},
     m_endTimeLeafName{"event_end_t"},
     m_triggersLeafName{"triggers"},
@@ -144,7 +146,7 @@ void HierarchyAnalysisAlgorithm::SetEventRunMCIdInfo()
 
     if (m_eventTree)
     {
-        // Sets m_event, m_run, m_subRun, m_unixTime, m_startTime, m_endTime & m_triggers
+        // Sets m_event, m_run, m_subRun, m_unixTime, m_unixTimeUsec, m_startTime, m_endTime & m_triggers
         const int iEntry = m_count + m_eventsToSkip;
         m_eventTree->GetEntry(iEntry);
 
@@ -452,6 +454,7 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "run", m_run));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "subRun", m_subRun));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "unixTime", m_unixTime));
+    PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "unixTimeUsec", m_unixTimeUsec));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "startTime", m_startTime));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "endTime", m_endTime));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "triggers", m_triggers));
@@ -621,6 +624,8 @@ StatusCode HierarchyAnalysisAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     PANDORA_RETURN_RESULT_IF_AND_IF(
         STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UnixTimeLeafName", m_unixTimeLeafName));
     PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UnixTimeUsecLeafName", m_unixTimeUsecLeafName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
         STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "StartTimeLeafName", m_startTimeLeafName));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "EndTimeLeafName", m_endTimeLeafName));
     PANDORA_RETURN_RESULT_IF_AND_IF(
@@ -652,6 +657,7 @@ StatusCode HierarchyAnalysisAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
                 m_eventTree->SetBranchStatus(m_runLeafName.c_str(), 1);
                 m_eventTree->SetBranchStatus(m_subRunLeafName.c_str(), 1);
                 m_eventTree->SetBranchStatus(m_unixTimeLeafName.c_str(), 1);
+                m_eventTree->SetBranchStatus(m_unixTimeUsecLeafName.c_str(), 1);
                 m_eventTree->SetBranchStatus(m_startTimeLeafName.c_str(), 1);
                 m_eventTree->SetBranchStatus(m_endTimeLeafName.c_str(), 1);
                 m_eventTree->SetBranchStatus(m_triggersLeafName.c_str(), 1);
@@ -660,6 +666,7 @@ StatusCode HierarchyAnalysisAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
                 m_eventTree->SetBranchAddress(m_runLeafName.c_str(), &m_run);
                 m_eventTree->SetBranchAddress(m_subRunLeafName.c_str(), &m_subRun);
                 m_eventTree->SetBranchAddress(m_unixTimeLeafName.c_str(), &m_unixTime);
+                m_eventTree->SetBranchAddress(m_unixTimeUsecLeafName.c_str(), &m_unixTimeUsec);
                 m_eventTree->SetBranchAddress(m_startTimeLeafName.c_str(), &m_startTime);
                 m_eventTree->SetBranchAddress(m_endTimeLeafName.c_str(), &m_endTime);
                 m_eventTree->SetBranchAddress(m_triggersLeafName.c_str(), &m_triggers);


### PR DESCRIPTION
This propagates the [corresponding new field](https://github.com/DUNE/ndlar_flow/pull/195) from the flow file. It provides a more granular trigger time that includes an optional correction for any misalignment between the GPS second and the 2x2's pulse-per-second timestamp reset. When the CAFmaker is configured to use this field, we get good matching performance between 2x2 and Mx2 tracks.