### PR TITLE
Feature/howard truth matching with filtered hits

### DIFF
--- a/ndlarflow/h5_to_root_ndlarflow.py
+++ b/ndlarflow/h5_to_root_ndlarflow.py
@@ -136,7 +136,7 @@ def main(argv=None):
 
             # Note: in a few places below, we will want to have handy the spillID
             spillID = 0
-            if useData==False:
+            if useData==False and badEvt==False:
                 if promptKey=='prompt':
                     allSpillIDs=flow_out["charge/calib_prompt_hits","charge/packets","mc_truth/segments",hits_ids]["event_id"]
                     spillID=allSpillIDs.data[ ~allSpillIDs.mask ][0]
@@ -183,7 +183,7 @@ def main(argv=None):
                     backtrackMaskArr = np.ma.getmask(backtrackMasked)
                     matches = backtrackMasked.count(axis=1).astype('uint16')
                     # Fractions - note that "packet" is not always right terminology, e.g. with merged hits. Keeping nomenclature.
-                    packetFrac = backtrackHits['fraction'].data[~backtrackMaskArr]
+                    packetFrac = backtrackHits['fraction'].data[~backtrackMaskArr].astype('float32')
                     # Get the segment IDs then get the segments themselves
                     segmentIDs = backtrackHits['segment_ids'].data[~backtrackMaskArr]
                     all_segments = f['mc_truth/segments/data']

--- a/ndlarflow/rootToRootConversion.C
+++ b/ndlarflow/rootToRootConversion.C
@@ -89,7 +89,15 @@ void rootToRootConversion(
     tr->SetBranchAddress("event",&in_event);
     tr->SetBranchAddress("triggers",&in_triggers);
     tr->SetBranchAddress("unix_ts",&in_unix_ts);
-    tr->SetBranchAddress("unix_ts_usec",&in_unix_ts_usec);
+
+    // Is this a legacy mode tree?
+    bool legacyMode=false;
+    if ( !tr->FindBranch("unix_ts_usec") ){
+      legacyMode=true;
+    }
+    if (!legacyMode)
+      tr->SetBranchAddress("unix_ts_usec",&in_unix_ts_usec);
+
     tr->SetBranchAddress("event_start_t",&in_event_start_t);
     tr->SetBranchAddress("event_end_t",&in_event_end_t);
     tr->SetBranchAddress("subevent",&in_subevent);
@@ -208,7 +216,8 @@ void rootToRootConversion(
     outgoingTree->Branch("event_end_t", &event_end_t);
     outgoingTree->Branch("triggers",&triggers);
     outgoingTree->Branch("unix_ts", &unix_ts);
-    outgoingTree->Branch("unix_ts_usec", &unix_ts_usec);
+    if (!legacyMode)
+      outgoingTree->Branch("unix_ts_usec", &unix_ts_usec);
     outgoingTree->Branch("nhits",&nhits);
     outgoingTree->Branch("x", &x);
     outgoingTree->Branch("y", &y);
@@ -411,7 +420,8 @@ void rootToRootConversion(
         event_start_t = in_event_start_t;
         event_end_t = in_event_end_t;
         unix_ts = in_unix_ts;
-        unix_ts_usec = in_unix_ts_usec;
+	if (!legacyMode)
+	  unix_ts_usec = in_unix_ts_usec;
         triggers = in_triggers;
 	
         // fill up the vectors for as much stuff as we can in this subevent:


### PR DESCRIPTION
Several updates, broadly speaking:

1. Contains the `SpillID` fix as in https://github.com/PandoraPFA/LArRecoND/pull/41 . However it also moves where this is determined to earlier in the event loop. Then I can use the Spill ID to reduce the time taken to get the truth info in the new scheme that should also work for filtered ("final") hits.
2. Update to a scheme that I believe should also work for filtered ("final") hits. Thanks to Kevin W for the help in getting that together.
3. Inspired by Maria Brigida, adding a legacy mode for the conversion

This would benefit from additional testing (and if we have a file with the usec variable added it would be good to test the LegacyMode=0 (default)), but making a PR for now.