### PR TITLE
Feature/howard quick conversion fixes

### DIFF
--- a/ndlarflow/h5_to_root_ndlarflow.py
+++ b/ndlarflow/h5_to_root_ndlarflow.py
@@ -221,6 +221,12 @@ def main(argv=None):
             # Removing duplicate hits_id instantiation and getting rid of hits_id_raw which is unused
             #######################################
             if badEvt==False:
+                # Check if the only values are masked and call this a bad event if so
+                if np.ma.count_masked(event_calib_prompt_hits["z"][0]) == len(event_calib_prompt_hits[0]):
+                    print('This event has a hit z array ( len hits =', len(event_calib_prompt_hits[0]), ') that appears to be only masked values, setting as bad event. Trigger type (',triggerIDs[ievt],')')
+                    badEvt=True
+
+            if badEvt==False:
                 hits_z = (np.ma.getdata(event_calib_prompt_hits["z"][0])+trueZOffset).astype('float32')
                 hits_y = ( np.ma.getdata(event_calib_prompt_hits["y"][0])+trueYOffset ).astype('float32')
                 hits_x = ( np.ma.getdata(event_calib_prompt_hits["x"][0])+trueXOffset ).astype('float32')
@@ -237,7 +243,7 @@ def main(argv=None):
                 hits_ts = np.array([]).astype('float32')
                 hits_ids = np.array([])
 
-            if len(hits_ids)<2:
+            if badEvt==False and len(hits_ids)<2:
                 print('This event has < 2 hit IDs, setting as bad event. Trigger type (',triggerIDs[ievt],')')
                 badEvt=True
 

--- a/ndlarflow/rootToRootConversion.C
+++ b/ndlarflow/rootToRootConversion.C
@@ -428,8 +428,11 @@ void rootToRootConversion(
                 sum_matches+=(unsigned long)matches[idxHit];
             }
         }
+	// in case there are no hits, set up a 0 here so we don't seg fault later and push back an empty match vector
+	if ( Nhits==0 && isMC )
+	    all_matches.push_back(0);
 
-        if ( isMC ) {
+	if ( isMC ) {
             // Because the arrays of matches and hits need not be sync'ed, we'll fill up
             //   vectors will all the info for the event here and then break it into sub-
             //   vectors at the end of the event...


### PR DESCRIPTION
This PR makes a number of changes in response to Will's testing of 2x2 sim using the refactored conversion script and workflow.

I suspect something is happening with the truth info in the FLOW files in the testing, but I think these are largely decent quality of life changes anyway.

1. Write a bogus subevent in the Python macro to get Uproot to use the proper branch types. Tell rootToRoot to skip the first subevent.

2. Check the size of the "z" of the hits, if none would pass the filter (of `np.ma` mask) then call it a bad event. With this change, I was seeing an issue with the rootToRoot conversion: adding a change to rootToRoot in the case of `Nhit`=0 to add an entry to the matches to consider with 0.

3. Improve slice ID grabbing. A few of these bits I think we'd also want to propagate into PR42.
4. Related to this, put the grabbing of true neutrino stuff behind a check on badEvt and return nothing if this is a bad event. Note that we're seeing some events that don't get called bad event until we go to grab the slice ID and find it empty. Anecdotally at least from the 2 files I was looking at, these seem to be mostly small in number of hits and cases where none of the hits have a truth match?

Not tested spectacularly well, but did run on a few FLOW files for Will's testing, and pretty much just with prompt hits on my end. Thanks to Will F for reaching out about the issues he was seeing and helping to debug/test.