### PR TITLE
ROCK MUON TAGGING: create CR worker instances combining multiple TPCs that share the same xy coordinates

### DIFF
--- a/include/LArRecoNDFormat.h
+++ b/include/LArRecoNDFormat.h
@@ -71,6 +71,7 @@ public:
     std::vector<int> *m_nVHits = nullptr;
     std::vector<int> *m_nWHits = nullptr;
     std::vector<int> *m_isShower = nullptr;
+    std::vector<int> *m_isClearRockOrCosmic = nullptr;
     std::vector<float> *m_trackScore = nullptr;
     std::vector<int> *m_recoPDG = nullptr;
     std::vector<int> *m_isRecoPrimary = nullptr;
@@ -144,6 +145,7 @@ public:
     TBranch *m_b_nVHits = nullptr;
     TBranch *m_b_nWHits = nullptr;
     TBranch *m_b_isShower = nullptr;
+    TBranch *m_b_isClearRockOrCosmic = nullptr;
     TBranch *m_b_trackScore = nullptr;
     TBranch *m_b_recoPDG = nullptr;
     TBranch *m_b_isRecoPrimary = nullptr;
@@ -270,6 +272,7 @@ void LArRecoNDFormat::Init(TTree *tree)
     m_fChain->SetBranchAddress("nVHits", &m_nVHits, &m_b_nVHits);
     m_fChain->SetBranchAddress("nWHits", &m_nWHits, &m_b_nWHits);
     m_fChain->SetBranchAddress("isShower", &m_isShower, &m_b_isShower);
+    m_fChain->SetBranchAddress("isClearRockOrCosmic", &m_isClearRockOrCosmic, &m_b_isClearRockOrCosmic);
     m_fChain->SetBranchAddress("trackScore", &m_trackScore, &m_b_trackScore);
     m_fChain->SetBranchAddress("recoPDG", &m_recoPDG, &m_b_recoPDG);
     m_fChain->SetBranchAddress("isRecoPrimary", &m_isRecoPrimary, &m_b_isRecoPrimary);

--- a/include/LArSP.h
+++ b/include/LArSP.h
@@ -63,8 +63,12 @@ public:
     std::vector<float> *m_y = nullptr;
     std::vector<float> *m_z = nullptr;
     std::vector<float> *m_ts = nullptr;
-    std::vector<float> *m_charge = nullptr;
+    std::vector<uint8_t> *m_io_group = nullptr;
+    std::vector<uint8_t> *m_io_channel = nullptr;
+    std::vector<uint8_t> *m_chip_id = nullptr;
+    std::vector<uint8_t> *m_channel_id = nullptr;
     std::vector<float> *m_E = nullptr;
+    std::vector<float> *m_charge = nullptr;
 
     // List of branches
     TBranch *m_b_eventID = nullptr;
@@ -76,6 +80,10 @@ public:
     TBranch *m_b_y = nullptr;
     TBranch *m_b_z = nullptr;
     TBranch *m_b_ts = nullptr;
+    TBranch *m_b_io_group = nullptr;
+    TBranch *m_b_io_channel = nullptr;
+    TBranch *m_b_chip_id = nullptr;
+    TBranch *m_b_channel_id = nullptr;
     TBranch *m_b_charge = nullptr;
     TBranch *m_b_E = nullptr;
 };
@@ -142,6 +150,10 @@ void LArSP::Init(TTree *tree)
     m_fChain->SetBranchAddress("y", &m_y, &m_b_y);
     m_fChain->SetBranchAddress("z", &m_z, &m_b_z);
     m_fChain->SetBranchAddress("ts", &m_ts, &m_b_ts);
+    m_fChain->SetBranchAddress("io_group", &m_io_group, &m_b_io_group);
+    m_fChain->SetBranchAddress("io_channel", &m_io_channel, &m_b_io_channel);
+    m_fChain->SetBranchAddress("chip_id", &m_chip_id, &m_b_chip_id);
+    m_fChain->SetBranchAddress("channel_id", &m_channel_id, &m_b_channel_id);
     m_fChain->SetBranchAddress("charge", &m_charge, &m_b_charge);
     m_fChain->SetBranchAddress("E", &m_E, &m_b_E);
 }

--- a/include/MasterThreeDAlgorithm.h
+++ b/include/MasterThreeDAlgorithm.h
@@ -20,6 +20,7 @@
 namespace lar_content
 {
 
+typedef std::unordered_map<unsigned int, std::vector<const pandora::LArTPC *>> WorkerToLArTPCMap;
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 /**
@@ -35,6 +36,14 @@ public:
 
 protected:
     pandora::StatusCode Run() override;
+    
+    /**
+     *  @brief  Run the cosmic-ray reconstruction worker instances
+     *
+     *  @param  volumeIdToHitListMap the volume id to hit list map
+     *  @param  workerToLArTPCMap the worker id to LArTPC list map
+     */
+    pandora::StatusCode RunCosmicRayReconstruction(const VolumeIdToHitListMap &volumeIdToHitListMap, WorkerToLArTPCMap& workerToLArTPCMap) const;
 
     /**
      *  @brief  Run cosmic-ray hit removal, freeing hits in ambiguous pfos for further processing

--- a/include/MasterThreeDAlgorithm.h
+++ b/include/MasterThreeDAlgorithm.h
@@ -83,11 +83,12 @@ protected:
      *  @param  gapList the gap list
      *  @param  settingsFile the pandora settings file
      *  @param  name the pandora instance name
+     *  @param  id for the created worker instance (i.e. larTPCParameters.m_larTPCVolumeId)   
      *
      *  @return the address of the pandora instance
      */
     const pandora::Pandora *CreateWorkerInstance(const pandora::LArTPCMap &larTPCMap, const pandora::DetectorGapList &gapList,
-        const std::string &settingsFile, const std::string &name) const;
+        const std::string &settingsFile, const std::string &name, const unsigned int id) const;
 
     /**
      *  @brief  Initialize pandora worker instances

--- a/include/MasterThreeDAlgorithm.h
+++ b/include/MasterThreeDAlgorithm.h
@@ -128,7 +128,10 @@ protected:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
 
+    typedef std::vector<RockMuonTaggingTool*> RockMuonTaggingToolVector;
+
     bool m_shouldRunRockMus_Xworkers;   ///< Whether to run rock muons reconstruction using a columnar X worker
+    RockMuonTaggingToolVector m_rockMuonTaggingToolVector; ///< The cosmic-ray tagging tool vector
 };
 
 } // namespace lar_content

--- a/include/MasterThreeDAlgorithm.h
+++ b/include/MasterThreeDAlgorithm.h
@@ -46,14 +46,7 @@ protected:
      *  @param  workerToLArTPCMap the worker id to LArTPC list map
      */
     pandora::StatusCode RunCosmicRayReconstruction(const VolumeIdToHitListMap &volumeIdToHitListMap, WorkerToLArTPCMap& workerToLArTPCMap) const;
-
-    /**
-     *  @brief  Run cosmic-ray hit removal, freeing hits in ambiguous pfos for further processing
-     *
-     *  @param  ambiguousPfos the list of ambiguous cosmic-ray pfos
-     */
-    pandora::StatusCode RunCosmicRayHitRemoval(const pandora::PfoList &ambiguousPfos) const;
-
+    
     /**
      *  @brief  Tag clear, unambiguous cosmic-ray pfos
      *
@@ -61,7 +54,15 @@ protected:
      *  @param  clearCosmicRayPfos to receive the list of clear cosmic-ray pfos
      *  @param  ambiguousPfos to receive the list of ambiguous cosmic-ray pfos for further analysis
      */
-    pandora::StatusCode TagCosmicRayPfos(const PfoToFloatMap &stitchedPfosToX0Map, pandora::PfoList &clearCosmicRayPfos, pandora::PfoList &ambiguousPfos) const;
+    pandora::StatusCode TagCosmicRayPfos(
+        const PfoToFloatMap &stitchedPfosToX0Map, pandora::PfoList &clearCosmicRayPfos, pandora::PfoList &ambiguousPfos) const override;
+
+    /**
+     *  @brief  Run cosmic-ray hit removal, freeing hits in ambiguous pfos for further processing
+     *
+     *  @param  ambiguousPfos the list of ambiguous cosmic-ray pfos
+     */
+    pandora::StatusCode RunCosmicRayHitRemoval(const pandora::PfoList &ambiguousPfos) const;
 
     /**
      *  @brief  Run the event slicing procedures, dividing available hits up into distinct 3D regions
@@ -131,6 +132,7 @@ protected:
     typedef std::vector<RockMuonTaggingTool*> RockMuonTaggingToolVector;
 
     bool m_shouldRunRockMus_Xworkers;   ///< Whether to run rock muons reconstruction using a columnar X worker
+    bool m_tagRockMuons;  ///< bool to activate tagging of rock muons
     RockMuonTaggingToolVector m_rockMuonTaggingToolVector; ///< The cosmic-ray tagging tool vector
 };
 

--- a/include/MasterThreeDAlgorithm.h
+++ b/include/MasterThreeDAlgorithm.h
@@ -15,6 +15,8 @@
 #include "larpandoracontent/LArControlFlow/MultiPandoraApi.h"
 #include "larpandoracontent/LArObjects/LArCaloHit.h"
 
+#include "RockMuonTaggingTool.h"
+
 #include <unordered_map>
 
 namespace lar_content
@@ -32,7 +34,7 @@ public:
     /**
      *  @brief  Default constructor
      */
-    MasterThreeDAlgorithm() = default;
+    MasterThreeDAlgorithm();
 
 protected:
     pandora::StatusCode Run() override;
@@ -51,6 +53,15 @@ protected:
      *  @param  ambiguousPfos the list of ambiguous cosmic-ray pfos
      */
     pandora::StatusCode RunCosmicRayHitRemoval(const pandora::PfoList &ambiguousPfos) const;
+
+    /**
+     *  @brief  Tag clear, unambiguous cosmic-ray pfos
+     *
+     *  @param  stitchedPfosToX0Map a map of cosmic-ray pfos that have been stitched between lar tpcs to the X0 shift
+     *  @param  clearCosmicRayPfos to receive the list of clear cosmic-ray pfos
+     *  @param  ambiguousPfos to receive the list of ambiguous cosmic-ray pfos for further analysis
+     */
+    pandora::StatusCode TagCosmicRayPfos(const PfoToFloatMap &stitchedPfosToX0Map, pandora::PfoList &clearCosmicRayPfos, pandora::PfoList &ambiguousPfos) const;
 
     /**
      *  @brief  Run the event slicing procedures, dividing available hits up into distinct 3D regions
@@ -116,6 +127,8 @@ protected:
     pandora::StatusCode GetVolumeIdToHitListMap(VolumeIdToHitListMap &volumeIdToHitListMap) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
+
+    bool m_shouldRunRockMus_Xworkers;   ///< Whether to run rock muons reconstruction using a columnar X worker
 };
 
 } // namespace lar_content

--- a/include/MasterThreeDAlgorithm.h
+++ b/include/MasterThreeDAlgorithm.h
@@ -92,8 +92,10 @@ protected:
 
     /**
      *  @brief  Initialize pandora worker instances
+     *
+     *  @param workerToLArTPCMap to map each worker instance to the list of TPCs it acts on
      */
-    pandora::StatusCode InitializeWorkerInstances();
+    pandora::StatusCode InitializeWorkerInstances(WorkerToLArTPCMap& workerToLArTPCMap);
 
     /**
      *  @brief  Get the mapping from lar tpc volume id to lists of all hits, and truncated hits

--- a/include/PandoraInterface.h
+++ b/include/PandoraInterface.h
@@ -37,6 +37,9 @@ namespace lar_nd_reco
 
 typedef std::map<int, float> MCParticleEnergyMap;
 typedef std::vector<LArVoxel> LArVoxelList;
+std::map<int, int> ioGroup2tcpIDMap_2x2 = {
+      {1,7}, {2,6}, {3,5}, {4,4}, {5,3}, {6,2}, {7,1}, {8,0}
+    };
 
 /**
  *  @brief  Parameters class

--- a/include/PandoraInterface.h
+++ b/include/PandoraInterface.h
@@ -83,6 +83,7 @@ public:
     bool m_shouldRunSlicing;            ///< Whether to slice events into separate regions for processing
     bool m_shouldRunNeutrinoRecoOption; ///< Whether to run neutrino reconstruction for each slice
     bool m_shouldRunCosmicRecoOption;   ///< Whether to run cosmic-ray reconstruction for each slice
+    bool m_shouldRunRockMus_Xworkers;   ///< Whether to run rock muons reconstruction using a columnar X worker
     bool m_shouldPerformSliceId;        ///< Whether to identify slices and select most appropriate pfos
     bool m_printOverallRecoStatus;      ///< Whether to print current operation status messages
 
@@ -123,6 +124,7 @@ inline Parameters::Parameters() :
     m_shouldRunSlicing(true),
     m_shouldRunNeutrinoRecoOption(true),
     m_shouldRunCosmicRecoOption(true),
+    m_shouldRunRockMus_Xworkers(true), 
     m_shouldPerformSliceId(true),
     m_printOverallRecoStatus(false),
     m_nEventsToSkip(0),

--- a/include/PandoraInterface.h
+++ b/include/PandoraInterface.h
@@ -37,9 +37,18 @@ namespace lar_nd_reco
 
 typedef std::map<int, float> MCParticleEnergyMap;
 typedef std::vector<LArVoxel> LArVoxelList;
+
 std::map<int, int> ioGroup2tcpIDMap_2x2 = {
       {1,7}, {2,6}, {3,5}, {4,4}, {5,3}, {6,2}, {7,1}, {8,0}
     };
+
+auto ioGroup2tcpIDMap_NDLAr = [](int io_group)
+{ 
+  if (io_group % 2 == 0) // even 
+      return io_group / 2 - 1;
+  else 
+      return io_group / 2;
+};
 
 /**
  *  @brief  Parameters class

--- a/include/PandoraInterface.h
+++ b/include/PandoraInterface.h
@@ -38,6 +38,15 @@ namespace lar_nd_reco
 typedef std::map<int, float> MCParticleEnergyMap;
 typedef std::vector<LArVoxel> LArVoxelList;
 
+// The io_group identifies the hit's readout drift volume.
+// Since the hit timing (t0) is currently unavailable,
+// reconstructed hit positions may be shifted across the
+// cathode into the neighboring drift volume, leading to an
+// incorrect TPC assignment if based solely on the hit
+// coordinates. As a readout-level quantity, io_group always
+// identifies the correct drift volume. The current io_group-to-TPC
+// mapping is empirical and hard-coded.
+//
 std::map<int, int> ioGroup2tcpIDMap_2x2 = {
       {1,7}, {2,6}, {3,5}, {4,4}, {5,3}, {6,2}, {7,1}, {8,0}
     };

--- a/include/PandoraInterface.h
+++ b/include/PandoraInterface.h
@@ -52,7 +52,7 @@ std::map<int, int> ioGroup2tcpIDMap_2x2 = {
     };
 
 std::map<int, int> ioGroup2tcpIDMap_FSD = {
-  {1,0}, {2,0}, {3,1}, {4,4}
+  {1,1}, {2,1}, {3,0}, {4,0}
 };
 
 auto ioGroup2tcpIDMap_NDLAr = [](int io_group)

--- a/include/PandoraInterface.h
+++ b/include/PandoraInterface.h
@@ -51,6 +51,10 @@ std::map<int, int> ioGroup2tcpIDMap_2x2 = {
       {1,7}, {2,6}, {3,5}, {4,4}, {5,3}, {6,2}, {7,1}, {8,0}
     };
 
+std::map<int, int> ioGroup2tcpIDMap_FSD = {
+  {1,0}, {2,0}, {3,1}, {4,4}
+};
+
 auto ioGroup2tcpIDMap_NDLAr = [](int io_group)
 { 
   if (io_group % 2 == 0) // even 

--- a/include/PandoraOuterface.h
+++ b/include/PandoraOuterface.h
@@ -325,6 +325,7 @@ private:
     std::vector<int> m_out_nVHits;
     std::vector<int> m_out_nWHits;
     std::vector<int> m_out_isShower;
+    std::vector<int> m_out_isClearRockOrCosmic;
     std::vector<float> m_out_trackScore;
     std::vector<int> m_out_recoPDG;
     std::vector<int> m_out_isRecoPrimary;
@@ -497,6 +498,7 @@ NDRecoOutputData::NDRecoOutputData(const std::string filename)
     m_treeOut->Branch("nVHits", &m_out_nVHits);
     m_treeOut->Branch("nWHits", &m_out_nWHits);
     m_treeOut->Branch("isShower", &m_out_isShower);
+    m_treeOut->Branch("isClearRockOrCosmic", &m_out_isClearRockOrCosmic);
     m_treeOut->Branch("trackScore", &m_out_trackScore);
     m_treeOut->Branch("recoPDG", &m_out_recoPDG);
     m_treeOut->Branch("isRecoPrimary", &m_out_isRecoPrimary);
@@ -632,6 +634,7 @@ void NDRecoOutputData::ClearData()
     m_out_nVHits.clear();
     m_out_nWHits.clear();
     m_out_isShower.clear();
+    m_out_isClearRockOrCosmic.clear();
     m_out_trackScore.clear();
     m_out_recoPDG.clear();
     m_out_isRecoPrimary.clear();
@@ -813,6 +816,7 @@ void NDRecoOutputData::FillBasicBranches(const std::unique_ptr<LArRecoNDFormat> 
     m_out_nVHits.insert(m_out_nVHits.end(), inputSpill->m_nVHits->begin(), inputSpill->m_nVHits->end());
     m_out_nWHits.insert(m_out_nWHits.end(), inputSpill->m_nWHits->begin(), inputSpill->m_nWHits->end());
     m_out_isShower.insert(m_out_isShower.end(), inputSpill->m_isShower->begin(), inputSpill->m_isShower->end());
+    m_out_isClearRockOrCosmic.insert(m_out_isClearRockOrCosmic.end(), inputSpill->m_isClearRockOrCosmic->begin(), inputSpill->m_isClearRockOrCosmic->end());
     m_out_trackScore.insert(m_out_trackScore.end(), inputSpill->m_trackScore->begin(), inputSpill->m_trackScore->end());
     m_out_recoPDG.insert(m_out_recoPDG.end(), inputSpill->m_recoPDG->begin(), inputSpill->m_recoPDG->end());
     m_out_isRecoPrimary.insert(m_out_isRecoPrimary.end(), inputSpill->m_isRecoPrimary->begin(), inputSpill->m_isRecoPrimary->end());

--- a/include/RockMuonTaggingTool.h
+++ b/include/RockMuonTaggingTool.h
@@ -1,10 +1,11 @@
-/**
- *  @file   include/RockMuonTaggingTool.h
+/** 
+ * @file   include/RockMuonTaggingTool.h
  *
  *  @brief  Header file for the rock muon tagging tool class.
  *
  *  $Log: $
  */
+
 #ifndef LAR_ROCK_MUON_TAGGING_TOOL_H
 #define LAR_ROCK_MUON_TAGGING_TOOL_H 1
 
@@ -19,6 +20,7 @@ namespace lar_content
 /**
  *  @brief  RockMuonTaggingAlgorithm class
  */
+
 class RockMuonTaggingTool : public CosmicRayTaggingTool
 {
   public:
@@ -28,6 +30,13 @@ class RockMuonTaggingTool : public CosmicRayTaggingTool
     RockMuonTaggingTool();
 
     void FindAmbiguousPfos( const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm) override;
+
+    /**
+     *  @brief Tag clear rock muons and exclude it from ambiguousPfos 
+     *
+     *  @param  ambiguousPfos input pfos list
+     */
+    pandora::StatusCode TagRockMuonPfos(pandora::PfoList& ambiguousPfos) const;
 
   private:
     /**
@@ -42,23 +51,12 @@ class RockMuonTaggingTool : public CosmicRayTaggingTool
     /**
      *  @brief  Check if each candidate is throughgoing (i.e emerging and exiting from any of the detector boundaies)
      *
-     *  @param  candidates input list of candidates
-     *  @param  pfoToIsThroughgoingMap output mapping between candidates Pfos and if they are top to bottom
+     *  @param  candidate input
      */
-    void CheckIfThroughgoing(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsThroughgoingMap) const;
-
-    /**
-     *  @brief  Tag Pfos which are likely to be a CR muon
-     *
-     *  @param  candidates input list of candidates
-     *  @param  pfoToIsLikelyRockMuonMap to receive the output mapping between Pfos and a boolean deciding if they are likely a rock muon
-     *  @param  pfoToIsThroughgoingMap output mapping between candidates Pfos and if they are top to bottom
-     */
-    void TagRockMuons(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsLikelyRockMuonMap, const PfoToBoolMap &pfoToIsThroughgoingMap) const;
+    bool CheckIfThroughgoing(const CRCandidate &candidate) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
 
-    bool m_tagRockMuons;  ///< bool to activate tagging of rock muons
     float m_marginX; ///< the minimum distance from the dector X-face to define a fiducial volume for tagging
     float m_marginY; ///< the minimum distance from the dector Y-face to define a fiducial volume for tagging
     float m_marginZ; ///< the minimum distance from the dector Z-face to define a fiducial volume for tagging

--- a/include/RockMuonTaggingTool.h
+++ b/include/RockMuonTaggingTool.h
@@ -1,0 +1,68 @@
+/**
+ *  @file   include/RockMuonTaggingTool.h
+ *
+ *  @brief  Header file for the rock muon tagging tool class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_ROCK_MUON_TAGGING_TOOL_H
+#define LAR_ROCK_MUON_TAGGING_TOOL_H 1
+
+#include "larpandoracontent/LArControlFlow/MasterAlgorithm.h"
+#include "larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h"
+
+#include <unordered_map>
+
+namespace lar_content
+{
+
+/**
+ *  @brief  RockMuonTaggingAlgorithm class
+ */
+class RockMuonTaggingTool : public CosmicRayTaggingTool
+{
+  public:
+    /**
+     *  @brief  Default constructor
+     */
+    RockMuonTaggingTool();
+
+    void FindAmbiguousPfos( const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm) override;
+
+  private:
+    /**
+     *  @brief Check if a 3D point is inside the detector boundaies with margins 
+     *
+     *  @param  x point x coordinate
+     *  @param  y point y coordinate
+     *  @param  z point z coordinate
+     */   
+    bool IsOutsideBox(const float x, const float y, const float z) const;
+  
+    /**
+     *  @brief  Check if each candidate is throughgoing (i.e emerging and exiting from any of the detector boundaies)
+     *
+     *  @param  candidates input list of candidates
+     *  @param  pfoToIsThroughgoingMap output mapping between candidates Pfos and if they are top to bottom
+     */
+    void CheckIfThroughgoing(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsThroughgoingMap) const;
+
+    /**
+     *  @brief  Tag Pfos which are likely to be a CR muon
+     *
+     *  @param  candidates input list of candidates
+     *  @param  pfoToIsLikelyRockMuonMap to receive the output mapping between Pfos and a boolean deciding if they are likely a rock muon
+     *  @param  pfoToIsThroughgoingMap output mapping between candidates Pfos and if they are top to bottom
+     */
+    void TagRockMuons(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsLikelyRockMuonMap, const PfoToBoolMap &pfoToIsThroughgoingMap) const;
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
+
+    bool m_tagRockMuons;  ///< bool to activate tagging of rock muons
+    float m_marginX; ///< the minimum distance from the dector X-face to define a fiducial volume for tagging
+    float m_marginY; ///< the minimum distance from the dector Y-face to define a fiducial volume for tagging
+    float m_marginZ; ///< the minimum distance from the dector Z-face to define a fiducial volume for tagging
+};
+} // namespace lar_content
+
+#endif // #ifndef LAR_ROCK_MUON_TAGGING_TOOL_H

--- a/include/RockMuonTaggingTool.h
+++ b/include/RockMuonTaggingTool.h
@@ -63,6 +63,6 @@ class RockMuonTaggingTool : public CosmicRayTaggingTool
     float m_marginY; ///< the minimum distance from the dector Y-face to define a fiducial volume for tagging
     float m_marginZ; ///< the minimum distance from the dector Z-face to define a fiducial volume for tagging
 };
-} // namespace lar_content
 
+} // namespace lar_cont::ent
 #endif // #ifndef LAR_ROCK_MUON_TAGGING_TOOL_H

--- a/settings/PandoraSettings_Cosmic_Standard_ThreeD.xml
+++ b/settings/PandoraSettings_Cosmic_Standard_ThreeD.xml
@@ -1,0 +1,365 @@
+<pandora>
+    <!-- GLOBAL SETTINGS -->
+    <IsMonitoringEnabled>false</IsMonitoringEnabled>
+    <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
+    <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
+
+    <!-- ALGORITHM SETTINGS -->
+    <algorithm type = "LArPreProcessingThreeD">
+        <OutputCaloHitListNameU>CaloHitListU</OutputCaloHitListNameU>
+        <OutputCaloHitListNameV>CaloHitListV</OutputCaloHitListNameV>
+        <OutputCaloHitListNameW>CaloHitListW</OutputCaloHitListNameW>
+        <OutputCaloHitListName3D>CaloHitList3D</OutputCaloHitListName3D>
+        <FilteredCaloHitListName>CaloHitList2D</FilteredCaloHitListName>
+        <CurrentCaloHitListReplacement>CaloHitList2D</CurrentCaloHitListReplacement>
+    </algorithm>
+
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArPreProcessingThreeD</InputStageName> -->
+    <!--   <InputCaloHitList3DName>CaloHitList3D</InputCaloHitList3DName> -->
+    <!--   <InputCaloHitListUName>CaloHitListU</InputCaloHitListUName> -->
+    <!--   <InputCaloHitListVName>CaloHitListV</InputCaloHitListVName> -->
+    <!--   <InputCaloHitListWName>CaloHitListW</InputCaloHitListWName> -->
+    <!--   <InputCaloHitList2DName>CaloHitList2D</InputCaloHitList2DName> -->
+    <!-- </algorithm> -->
+    <!---->
+        <!-- Use 3D hits to make the 2D clusters -->
+    <algorithm type = "LArSimpleClusterCreationThreeD">
+        <!-- <InputCaloHitListNameU>CaloHitListU</InputCaloHitListNameU> -->
+        <!-- <InputCaloHitListNameV>CaloHitListV</InputCaloHitListNameV> -->
+        <!-- <InputCaloHitListNameW>CaloHitListW</InputCaloHitListNameW> -->
+        <InputCaloHitListName3D>CaloHitList3D</InputCaloHitListName3D>
+        <!-- <OutputClusterListNameU>ClustersU</OutputClusterListNameU> -->
+        <!-- <OutputClusterListNameV>ClustersV</OutputClusterListNameV> -->
+        <!-- <OutputClusterListNameW>ClustersW</OutputClusterListNameW> -->
+        <OutputClusterListName3D>Clusters3D</OutputClusterListName3D>
+    </algorithm>
+
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArSimpleClusterCreationThreeD</InputStageName> -->
+    <!--   <InputClusterListName3D>Clusters3D</InputClusterListName3D> -->
+    <!-- </algorithm> -->
+
+    <algorithm type = "LArReplaceHitAndClusterLists">
+        <InputClusterListName>Clusters3D</InputClusterListName>
+        <InputCaloHitListName>CaloHitList3D</InputCaloHitListName>
+    </algorithm>
+    <algorithm type = "LArLayerSplitting"/>
+    <algorithm type = "LArLongitudinalAssociation"/>
+    <algorithm type = "LArTransverseAssociation"/>
+    <algorithm type = "LArLongitudinalExtension"/>
+    <algorithm type = "LArTransverseExtension"/>
+    <algorithm type = "LArCrossGapsAssociation"/>
+    <algorithm type = "LArCrossGapsExtension"/>
+    <algorithm type = "LArOvershootSplitting"/>
+    <algorithm type = "LArBranchSplitting"/>
+    <algorithm type = "LArKinkSplitting"/>
+    <algorithm type = "LArTrackConsolidation">
+        <algorithm type = "LArSimpleClusterCreation" description = "ClusterRebuilding"/>
+    </algorithm>
+
+    <algorithm type = "LArCutClusterCharacterisationThreeD">
+        <InputClusterListNames>Clusters3D</InputClusterListNames>
+        <PathLengthRatioCut>5.0</PathLengthRatioCut>
+        <OverwriteExistingId>true</OverwriteExistingId>
+    </algorithm>
+
+    <algorithm type = "LArMergeClearTracksThreeD">
+        <InputClusterListName>Clusters3D</InputClusterListName>
+        <SlidingFitWindow>10</SlidingFitWindow>
+        <MaxGapLengthCut>30.0</MaxGapLengthCut>
+        <MaxGapTransverseCut>3.0</MaxGapTransverseCut>
+        <MinCosThetaCut>0.96</MinCosThetaCut>
+    </algorithm>
+
+    <algorithm type = "LArCreateTwoDClustersFromThreeD">
+        <InputCaloHitListNameU>CaloHitListU</InputCaloHitListNameU>
+        <InputCaloHitListNameV>CaloHitListV</InputCaloHitListNameV>
+        <InputCaloHitListNameW>CaloHitListW</InputCaloHitListNameW>
+        <InputClusterListName3D>Clusters3D</InputClusterListName3D>
+        <OutputClusterListNameU>ClustersU</OutputClusterListNameU>
+        <OutputClusterListNameV>ClustersV</OutputClusterListNameV>
+        <OutputClusterListNameW>ClustersW</OutputClusterListNameW>
+    </algorithm>
+
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArCreateTwoDClustersFromThreeD</InputStageName> -->
+    <!--   <InputClusterListName3D>Clusters3D</InputClusterListName3D> -->
+    <!--   <InputClusterListNameU>ClustersU</InputClusterListNameU> -->
+    <!--   <InputClusterListNameV>ClustersV</InputClusterListNameV> -->
+    <!--   <InputClusterListNameW>ClustersW</InputClusterListNameW> -->
+    <!-- </algorithm> -->
+
+    <!-- We have made the 2D clusters, so remove 3D for now to make hits available later -->
+    <algorithm type = "LArListDeletion" description = "3DClusterDeletion">
+        <ClusterListNames>Clusters3D</ClusterListNames>
+    </algorithm>
+
+    <!-- ThreeDTrackAlgorithms -->
+    <algorithm type = "LArThreeDTransverseTracks">
+        <InputClusterListNameU>ClustersU</InputClusterListNameU>
+        <InputClusterListNameV>ClustersV</InputClusterListNameV>
+        <InputClusterListNameW>ClustersW</InputClusterListNameW>
+        <OutputPfoListName>MuonParticles3D</OutputPfoListName>
+        <TrackTools>
+            <tool type = "LArClearTracks"/>
+            <tool type = "LArLongTracks"/>
+            <tool type = "LArOvershootTracks"><SplitMode>true</SplitMode></tool>
+            <tool type = "LArUndershootTracks"><SplitMode>true</SplitMode></tool>
+            <tool type = "LArOvershootTracks"><SplitMode>false</SplitMode></tool>
+            <tool type = "LArUndershootTracks"><SplitMode>false</SplitMode></tool>
+            <tool type = "LArMissingTrackSegment"/>
+            <tool type = "LArTrackSplitting"/>
+            <tool type = "LArLongTracks"><MinMatchedFraction>0.75</MinMatchedFraction><MinXOverlapFraction>0.75</MinXOverlapFraction></tool>
+            <tool type = "LArTracksCrossingGaps"><MinMatchedFraction>0.75</MinMatchedFraction><MinXOverlapFraction>0.75</MinXOverlapFraction></tool>
+            <tool type = "LArMissingTrack"/>
+        </TrackTools>
+      </algorithm>
+
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArThreeDTransverseTracks</InputStageName> -->
+    <!--   <InputPfoListNames>MuonParticles3D</InputPfoListNames> -->
+    <!-- </algorithm> -->
+
+    <algorithm type = "LArThreeDLongitudinalTracks">
+        <InputClusterListNameU>ClustersU</InputClusterListNameU>
+        <InputClusterListNameV>ClustersV</InputClusterListNameV>
+        <InputClusterListNameW>ClustersW</InputClusterListNameW>
+        <OutputPfoListName>MuonParticles3D</OutputPfoListName>
+        <TrackTools>
+            <tool type = "LArClearLongitudinalTracks"/>
+            <tool type = "LArMatchedEndPoints"/>
+        </TrackTools>
+    </algorithm>
+
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArThreeDLongitudinalTracks</InputStageName> -->
+    <!--   <InputPfoListNames>MuonParticles3D</InputPfoListNames> -->
+    <!-- </algorithm> -->
+
+    <algorithm type = "LArThreeDTrackFragments">
+        <MinClusterLength>10.</MinClusterLength>
+        <InputClusterListNameU>ClustersU</InputClusterListNameU>
+        <InputClusterListNameV>ClustersV</InputClusterListNameV>
+        <InputClusterListNameW>ClustersW</InputClusterListNameW>
+        <OutputPfoListName>MuonParticles3D</OutputPfoListName>
+        <TrackTools>
+            <tool type = "LArClearTrackFragments"/>
+        </TrackTools>
+        <algorithm type = "LArSimpleClusterCreation" description = "ClusterRebuilding"/>
+    </algorithm>
+
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArThreeDTrackFragments</InputStageName> -->
+    <!--   <InputPfoListNames>MuonParticles3D</InputPfoListNames> -->
+    <!-- </algorithm> -->
+
+    <algorithm type = "LArCosmicRayTrackMatching">
+        <InputClusterListNameU>ClustersU</InputClusterListNameU>
+        <InputClusterListNameV>ClustersV</InputClusterListNameV>
+        <InputClusterListNameW>ClustersW</InputClusterListNameW>
+        <OutputPfoListName>MuonParticles3D</OutputPfoListName>
+    </algorithm>
+
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArCosmicRayTrackMatching</InputStageName> -->
+    <!--   <InputPfoListNames>MuonParticles3D</InputPfoListNames> -->
+    <!-- </algorithm> -->
+
+    <algorithm type = "LArCosmicRayTrackRecovery">
+        <InputClusterListNameU>ClustersU</InputClusterListNameU>
+        <InputClusterListNameV>ClustersV</InputClusterListNameV>
+        <InputClusterListNameW>ClustersW</InputClusterListNameW>
+        <OutputPfoListName>MuonParticles3D</OutputPfoListName>
+    </algorithm>
+
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArCosmicRayTrackRecovery</InputStageName> -->
+    <!--   <InputPfoListNames>MuonParticles3D</InputPfoListNames> -->
+    <!-- </algorithm> -->
+
+    <!-- PruneClusters -->
+    <algorithm type = "LArListPruning" description = "ListPruning">
+        <WarnIfObjectsUnavailable>false</WarnIfObjectsUnavailable>
+        <ClusterListNames>ClustersU ClustersV ClustersW</ClusterListNames>
+    </algorithm>
+
+    <!-- DeltaRayClustering -->
+    <algorithm type = "LArClusteringParent">
+        <algorithm type = "LArSimpleClusterCreation" description = "ClusterFormation"/>
+        <InputCaloHitListName>CaloHitListW</InputCaloHitListName>
+        <ClusterListName>ClustersW</ClusterListName>
+        <ReplaceCurrentCaloHitList>false</ReplaceCurrentCaloHitList>
+        <ReplaceCurrentClusterList>false</ReplaceCurrentClusterList>
+    </algorithm>
+    <algorithm type = "LArClusteringParent">
+        <algorithm type = "LArSimpleClusterCreation" description = "ClusterFormation"/>
+        <InputCaloHitListName>CaloHitListU</InputCaloHitListName>
+        <ClusterListName>ClustersU</ClusterListName>
+        <ReplaceCurrentCaloHitList>false</ReplaceCurrentCaloHitList>
+        <ReplaceCurrentClusterList>false</ReplaceCurrentClusterList>
+    </algorithm>
+    <algorithm type = "LArClusteringParent">
+        <algorithm type = "LArSimpleClusterCreation" description = "ClusterFormation"/>
+        <InputCaloHitListName>CaloHitListV</InputCaloHitListName>
+        <ClusterListName>ClustersV</ClusterListName>
+        <ReplaceCurrentCaloHitList>false</ReplaceCurrentCaloHitList>
+        <ReplaceCurrentClusterList>false</ReplaceCurrentClusterList>
+    </algorithm>
+
+    <!-- DeltaRayAlgorithms -->
+    <algorithm type = "LArDeltaRayIdentification">
+        <ParentPfoListName>MuonParticles3D</ParentPfoListName>
+        <DaughterPfoListName>DeltaRayParticles3D</DaughterPfoListName>
+    </algorithm>
+    <algorithm type = "LArDeltaRayGrowing">
+        <InputClusterListName>ClustersW</InputClusterListName>
+        <ParentPfoListName>MuonParticles3D</ParentPfoListName>
+        <DaughterPfoListName>DeltaRayParticles3D</DaughterPfoListName>
+    </algorithm>
+    <algorithm type = "LArDeltaRayGrowing">
+        <InputClusterListName>ClustersU</InputClusterListName>
+        <ParentPfoListName>MuonParticles3D</ParentPfoListName>
+        <DaughterPfoListName>DeltaRayParticles3D</DaughterPfoListName>
+    </algorithm>
+    <algorithm type = "LArDeltaRayGrowing">
+        <InputClusterListName>ClustersV</InputClusterListName>
+        <ParentPfoListName>MuonParticles3D</ParentPfoListName>
+        <DaughterPfoListName>DeltaRayParticles3D</DaughterPfoListName>
+    </algorithm>
+    <algorithm type = "LArDeltaRayMatching">
+        <ParentPfoListName>MuonParticles3D</ParentPfoListName>
+        <DaughterPfoListName>DeltaRayParticles3D</DaughterPfoListName>
+        <InputClusterListNameU>ClustersU</InputClusterListNameU>
+        <InputClusterListNameV>ClustersV</InputClusterListNameV>
+        <InputClusterListNameW>ClustersW</InputClusterListNameW>
+    </algorithm>
+    <algorithm type = "LArUnattachedDeltaRays">
+        <PfoListName>DeltaRayParticles3D</PfoListName>
+    </algorithm>
+
+    <!-- TwoDRemnantAlgorithms -->
+    <algorithm type = "LArSimpleClusterGrowing">
+        <InputClusterListName>ClustersW</InputClusterListName>
+    </algorithm>
+    <algorithm type = "LArSimpleClusterGrowing">
+        <InputClusterListName>ClustersU</InputClusterListName>
+    </algorithm>
+    <algorithm type = "LArSimpleClusterGrowing">
+        <InputClusterListName>ClustersV</InputClusterListName>
+    </algorithm>
+    <algorithm type = "LArSimpleClusterMerging">
+        <InputClusterListName>ClustersW</InputClusterListName>
+    </algorithm>
+    <algorithm type = "LArSimpleClusterMerging">
+        <InputClusterListName>ClustersU</InputClusterListName>
+    </algorithm>
+    <algorithm type = "LArSimpleClusterMerging">
+        <InputClusterListName>ClustersV</InputClusterListName>
+    </algorithm>
+
+    <!-- ThreeDRemnantAlgorithms -->
+    <algorithm type = "LArThreeDRemnants">
+        <MinClusterCaloHits>5</MinClusterCaloHits>
+        <InputClusterListNameU>ClustersU</InputClusterListNameU>
+        <InputClusterListNameV>ClustersV</InputClusterListNameV>
+        <InputClusterListNameW>ClustersW</InputClusterListNameW>
+        <OutputPfoListName>MuonParticles3D</OutputPfoListName>
+        <TrackTools>
+            <tool type = "LArClearRemnants"/>
+            <tool type = "LArConnectedRemnants"/>
+        </TrackTools>
+    </algorithm>
+    <algorithm type = "LArThreeDRemnants">
+        <MinClusterCaloHits>2</MinClusterCaloHits>
+        <InputClusterListNameU>ClustersU</InputClusterListNameU>
+        <InputClusterListNameV>ClustersV</InputClusterListNameV>
+        <InputClusterListNameW>ClustersW</InputClusterListNameW>
+        <OutputPfoListName>MuonParticles3D</OutputPfoListName>
+        <TrackTools>
+            <tool type = "LArClearRemnants"/>
+            <tool type = "LArConnectedRemnants"/>
+            <tool type = "LArMopUpRemnants"/>
+        </TrackTools>
+    </algorithm>
+    <algorithm type = "LArCosmicRayShowerMatching">
+        <MinCaloHitsPerCluster>1</MinCaloHitsPerCluster>
+        <InputClusterListNameU>ClustersU</InputClusterListNameU>
+        <InputClusterListNameV>ClustersV</InputClusterListNameV>
+        <InputClusterListNameW>ClustersW</InputClusterListNameW>
+        <OutputPfoListName>MuonParticles3D</OutputPfoListName>
+    </algorithm>
+
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArCosmicRayShowerMatching</InputStageName> -->
+    <!--   <InputPfoListNames>MuonParticles3D</InputPfoListNames> -->
+    <!-- </algorithm> -->
+
+    <algorithm type = "LArIsolatedClusterMopUp">
+        <PfoListNames>MuonParticles3D DeltaRayParticles3D</PfoListNames>
+        <DaughterListNames>ClustersU ClustersV ClustersW</DaughterListNames>
+        <ExcludePfosContainingTracks>false</ExcludePfosContainingTracks>
+    </algorithm>
+
+    <algorithm type = "LArPfoThreeDHitAssignment">
+        <InputCaloHitList3DName>CaloHitList3D</InputCaloHitList3DName>
+        <InputPfoListNames>MuonParticles3D DeltaRayParticles3D</InputPfoListNames>
+        <OutputClusterListNames>MuonClusters3D DeltaRayClusters3D</OutputClusterListNames>
+    </algorithm>
+
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArPfoThreeDHitAssignment</InputStageName> -->
+    <!--   <InputPfoListNames>MuonParticles3D</InputPfoListNames> -->
+    <!-- </algorithm> -->
+
+    <!-- VertexAlgorithms -->
+    <algorithm type = "LArCosmicRayVertexBuilding">
+        <InputPfoListName>MuonParticles3D</InputPfoListName>
+        <OutputVertexListName>CRVertices3D</OutputVertexListName>
+    </algorithm>
+    
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArCosmicRayVertexBuilding</InputStageName> -->
+    <!--   <InputVertexListNames>CRVertices3D</InputVertexListNames> -->
+    <!-- </algorithm> -->
+
+    <!-- Track and shower building -->
+    <algorithm type = "LArTrackParticleBuilding">
+        <PfoListName>MuonParticles3D</PfoListName>
+        <VertexListName>CRVertices3D</VertexListName>
+    </algorithm>
+
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArTrackParticleBuilding</InputStageName> -->
+    <!--   <InputPfoListNames>MuonParticles3D</InputPfoListNames> -->
+    <!-- </algorithm> -->
+
+    <!-- Output list management -->
+    <algorithm type = "LArPostProcessing">
+        <PfoListNames>MuonParticles3D DeltaRayParticles3D</PfoListNames>
+        <VertexListNames>CRVertices3D</VertexListNames>
+        <ClusterListNames>ClustersU ClustersV ClustersW MuonClusters3D DeltaRayClusters3D</ClusterListNames>
+        <CaloHitListNames>CaloHitListU CaloHitListV CaloHitListW CaloHitList2D</CaloHitListNames>
+        <CurrentPfoListReplacement>MuonParticles3D</CurrentPfoListReplacement>
+    </algorithm>
+
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArPostProcessing</InputStageName> -->
+    <!--   <InputPfoListNames>MuonParticles3D</InputPfoListNames> -->
+    <!--   <InputVertexListNames>CRVertices3D</InputVertexListNames> -->
+    <!-- </algorithm> -->
+
+</pandora>

--- a/settings/PandoraSettings_Cosmic_Standard_ThreeD.xml
+++ b/settings/PandoraSettings_Cosmic_Standard_ThreeD.xml
@@ -1,7 +1,7 @@
 <pandora>
     <!-- GLOBAL SETTINGS -->
     <IsMonitoringEnabled>false</IsMonitoringEnabled>
-    <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
+    <ShouldDisplayAlgorithmInfo>true</ShouldDisplayAlgorithmInfo>
     <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
 
     <!-- ALGORITHM SETTINGS -->
@@ -26,13 +26,13 @@
     <!---->
         <!-- Use 3D hits to make the 2D clusters -->
     <algorithm type = "LArSimpleClusterCreationThreeD">
-        <!-- <InputCaloHitListNameU>CaloHitListU</InputCaloHitListNameU> -->
-        <!-- <InputCaloHitListNameV>CaloHitListV</InputCaloHitListNameV> -->
-        <!-- <InputCaloHitListNameW>CaloHitListW</InputCaloHitListNameW> -->
+        <InputCaloHitListNameU>CaloHitListU</InputCaloHitListNameU>
+        <InputCaloHitListNameV>CaloHitListV</InputCaloHitListNameV>
+        <InputCaloHitListNameW>CaloHitListW</InputCaloHitListNameW>
         <InputCaloHitListName3D>CaloHitList3D</InputCaloHitListName3D>
-        <!-- <OutputClusterListNameU>ClustersU</OutputClusterListNameU> -->
-        <!-- <OutputClusterListNameV>ClustersV</OutputClusterListNameV> -->
-        <!-- <OutputClusterListNameW>ClustersW</OutputClusterListNameW> -->
+        <OutputClusterListNameU>ClustersU</OutputClusterListNameU>
+        <OutputClusterListNameV>ClustersV</OutputClusterListNameV>
+        <OutputClusterListNameW>ClustersW</OutputClusterListNameW>
         <OutputClusterListName3D>Clusters3D</OutputClusterListName3D>
     </algorithm>
 
@@ -100,6 +100,8 @@
 
     <!-- ThreeDTrackAlgorithms -->
     <algorithm type = "LArThreeDTransverseTracks">
+        <!--adding this to reduce execution time, preserving physics performances (hopefully???)--> 
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <InputClusterListNameU>ClustersU</InputClusterListNameU>
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
@@ -126,6 +128,8 @@
     <!-- </algorithm> -->
 
     <algorithm type = "LArThreeDLongitudinalTracks">
+        <!--adding this to reduce execution time, preserving physics performances (hopefully???)--> 
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <InputClusterListNameU>ClustersU</InputClusterListNameU>
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
@@ -143,6 +147,8 @@
     <!-- </algorithm> -->
 
     <algorithm type = "LArThreeDTrackFragments">
+        <!--adding this to reduce execution time, preserving physics performances (hopefully???)--> 
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <MinClusterLength>10.</MinClusterLength>
         <InputClusterListNameU>ClustersU</InputClusterListNameU>
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
@@ -268,6 +274,8 @@
 
     <!-- ThreeDRemnantAlgorithms -->
     <algorithm type = "LArThreeDRemnants">
+        <!--adding this to reduce execution time, preserving physics performances (hopefully???)--> 
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <MinClusterCaloHits>5</MinClusterCaloHits>
         <InputClusterListNameU>ClustersU</InputClusterListNameU>
         <InputClusterListNameV>ClustersV</InputClusterListNameV>

--- a/settings/PandoraSettings_Cosmic_Standard_ThreeD.xml
+++ b/settings/PandoraSettings_Cosmic_Standard_ThreeD.xml
@@ -359,7 +359,7 @@
         <PfoListNames>MuonParticles3D DeltaRayParticles3D</PfoListNames>
         <VertexListNames>CRVertices3D</VertexListNames>
         <ClusterListNames>ClustersU ClustersV ClustersW MuonClusters3D DeltaRayClusters3D</ClusterListNames>
-        <CaloHitListNames>CaloHitListU CaloHitListV CaloHitListW CaloHitList2D</CaloHitListNames>
+        <CaloHitListNames>CaloHitListU CaloHitListV CaloHitListW CaloHitList2D CaloHitList3D</CaloHitListNames>
         <CurrentPfoListReplacement>MuonParticles3D</CurrentPfoListReplacement>
     </algorithm>
 

--- a/settings/PandoraSettings_Cosmic_Standard_ThreeD_cheated.xml
+++ b/settings/PandoraSettings_Cosmic_Standard_ThreeD_cheated.xml
@@ -1,0 +1,89 @@
+<pandora>
+    <!-- GLOBAL SETTINGS -->
+    <IsMonitoringEnabled>false</IsMonitoringEnabled>
+    <ShouldDisplayAlgorithmInfo>true</ShouldDisplayAlgorithmInfo>
+    <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
+
+    <!-- ALGORITHM SETTINGS -->
+    <algorithm type = "LArPreProcessingThreeD">
+        <OutputCaloHitListNameU>CaloHitListU</OutputCaloHitListNameU>
+        <OutputCaloHitListNameV>CaloHitListV</OutputCaloHitListNameV>
+        <OutputCaloHitListNameW>CaloHitListW</OutputCaloHitListNameW>
+        <OutputCaloHitListName3D>CaloHitList3D</OutputCaloHitListName3D>
+        <FilteredCaloHitListName>CaloHitList2D</FilteredCaloHitListName>
+        <CurrentCaloHitListReplacement>CaloHitList2D</CurrentCaloHitListReplacement>
+    </algorithm>
+
+    <!-- 2D cosmic-ray muon reconstruction, V View -->
+    <algorithm type = "LArClusteringParent">
+        <algorithm type = "LArCheatingClusterCreation" description = "ClusterFormation">
+            <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+            <MCParticleListName>Input</MCParticleListName>
+        </algorithm>
+        <InputCaloHitListName>CaloHitListV</InputCaloHitListName>
+        <ClusterListName>ClustersV</ClusterListName>
+        <ReplaceCurrentCaloHitList>false</ReplaceCurrentCaloHitList>
+        <ReplaceCurrentClusterList>true</ReplaceCurrentClusterList>
+    </algorithm>
+
+    <!-- 2D cosmic-ray muon reconstruction, W View -->
+    <algorithm type = "LArClusteringParent">
+        <algorithm type = "LArCheatingClusterCreation" description = "ClusterFormation">
+            <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+            <MCParticleListName>Input</MCParticleListName>
+        </algorithm>
+        <InputCaloHitListName>CaloHitListW</InputCaloHitListName>
+        <ClusterListName>ClustersW</ClusterListName>
+        <ReplaceCurrentCaloHitList>false</ReplaceCurrentCaloHitList>
+        <ReplaceCurrentClusterList>true</ReplaceCurrentClusterList>
+    </algorithm>
+    
+    <!-- 2D cosmic-ray muon reconstruction, U View -->
+    <algorithm type = "LArClusteringParent">
+        <algorithm type = "LArCheatingClusterCreation" description = "ClusterFormation">
+            <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+            <MCParticleListName>Input</MCParticleListName>
+        </algorithm>
+        <InputCaloHitListName>CaloHitListU</InputCaloHitListName>
+        <ClusterListName>ClustersU</ClusterListName>
+        <ReplaceCurrentCaloHitList>false</ReplaceCurrentCaloHitList>
+        <ReplaceCurrentClusterList>true</ReplaceCurrentClusterList>
+    </algorithm>
+
+    <!-- 3D neutrino reconstruction -->
+    <algorithm type = "LArClusteringParent">
+        <algorithm type = "LArCheatingClusterCreation" description = "ClusterFormation">
+            <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+            <MCParticleListName>Input</MCParticleListName>
+        </algorithm>
+        <InputCaloHitListName>CaloHitList3D</InputCaloHitListName>
+        <ClusterListName>Clusters3D</ClusterListName>
+        <ReplaceCurrentCaloHitList>false</ReplaceCurrentCaloHitList>
+        <ReplaceCurrentClusterList>true</ReplaceCurrentClusterList>
+    </algorithm>
+
+       <!-- 3D cosmic-ray muon reconstruction -->
+    <algorithm type = "LArCheatingPfoCreation">
+        <InputClusterListNames>Clusters3D ClustersU ClustersV ClustersW</InputClusterListNames>
+        <OutputPfoListName>MuonParticles3D</OutputPfoListName>
+        <OutputVertexListName>CRVertices3D</OutputVertexListName>
+        <MCParticleListName>Input</MCParticleListName>
+        <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+    </algorithm> 
+
+    <!-- Track and shower building -->
+    <algorithm type = "LArTrackParticleBuilding">
+        <PfoListName>MuonParticles3D</PfoListName>
+        <VertexListName>CRVertices3D</VertexListName>
+    </algorithm>
+
+    <!-- Output list management -->
+    <algorithm type = "LArPostProcessing">
+        <PfoListNames>MuonParticles3D</PfoListNames>
+        <VertexListNames>CRVertices3D</VertexListNames>
+        <ClusterListNames>ClustersU ClustersV ClustersW MuonClusters3D</ClusterListNames>
+        <CaloHitListNames>CaloHitListU CaloHitListV CaloHitListW CaloHitList2D</CaloHitListNames>
+        <CurrentPfoListReplacement>MuonParticles3D</CurrentPfoListReplacement>
+    </algorithm>
+
+</pandora>

--- a/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
@@ -1,0 +1,85 @@
+<pandora>
+    <!-- GLOBAL SETTINGS -->
+    <IsMonitoringEnabled>true</IsMonitoringEnabled>
+    <ShouldDisplayAlgorithmInfo>true</ShouldDisplayAlgorithmInfo>
+    <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
+
+    <!-- ALGORITHM SETTINGS -->
+    <algorithm type = "LArPreProcessingThreeD">
+        <OutputCaloHitListNameU>CaloHitListU</OutputCaloHitListNameU>
+        <OutputCaloHitListNameV>CaloHitListV</OutputCaloHitListNameV>
+        <OutputCaloHitListNameW>CaloHitListW</OutputCaloHitListNameW>
+        <OutputCaloHitListName3D>CaloHitList3D</OutputCaloHitListName3D>
+        <FilteredCaloHitListName>CaloHitList2D</FilteredCaloHitListName>
+        <CurrentCaloHitListReplacement>CaloHitList2D</CurrentCaloHitListReplacement>
+    </algorithm>
+
+    <algorithm type = "LArMasterThreeD">
+        <CRSettingsFile>PandoraSettings_Cosmic_Standard_ThreeD_cheated.xml</CRSettingsFile>
+        <NuSettingsFile>PandoraSettings_Neutrino_ThreeD_Cheated.xml</NuSettingsFile>
+        <SlicingSettingsFile>PandoraSettings_Slicing_ThreeD_Cheated.xml</SlicingSettingsFile>
+        <ShouldRunRockMus_Xworkers>true</ShouldRunRockMus_Xworkers>
+        <StitchingTools>
+          <tool type = "LArStitchingCosmicRayMerging">
+            <ThreeDStitchingMode>true</ThreeDStitchingMode>
+            <MinNCaloHits3D>10</MinNCaloHits3D>
+          </tool>
+          <tool type = "LArStitchingCosmicRayMerging">
+            <ThreeDStitchingMode>false</ThreeDStitchingMode>
+            <MinNCaloHits3D>10</MinNCaloHits3D>
+          </tool>
+        </StitchingTools>
+	<RockMuonTaggingTools>
+	  <tool type = "LArRockMuonTagging">
+	    <CutMode>cautious</CutMode>
+	    <TagRockMuons>true</TagRockMuons>
+	    <MarginX>5</MarginX>
+	    <MarginY>5</MarginY>
+	    <MarginZ>5</MarginZ>
+	  </tool>
+	</RockMuonTaggingTools>
+        <SliceIdTools>
+            <tool type = "LArSimpleNeutrinoId"/>
+        </SliceIdTools>
+        <InputHitListName>Input</InputHitListName>
+        <InputMCParticleListName>Input</InputMCParticleListName>
+        <PassMCParticlesToWorkerInstances>true</PassMCParticlesToWorkerInstances>
+        <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>
+        <RecreatedClusterListName>RecreatedClusters</RecreatedClusterListName>
+        <RecreatedVertexListName>RecreatedVertices</RecreatedVertexListName>
+        <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
+        <ShouldRemoveOutOfTimeHits>false</ShouldRemoveOutOfTimeHits>
+    </algorithm>
+
+    <algorithm type = "LArHierarchyAnalysis">
+      <EventFileName>/exp/dune/app/users/ingratta/tests/evaluate_z_stitching_metrics_w_cheatingWorkflow_on_2x2_simu/CONVERTED/MiniRun6.4_1E19_RHC.flow.0000000.FLOW.hdf5_hits.root</EventFileName>
+        <!-- <EventFileName>MicroProdN3p4_NDLAr_2E18_FHC.flow.geomfix.singles.nu.v251016.0000010.FLOW.hdf5_hits.root</EventFileName> -->
+	<EventTreeName>events</EventTreeName>
+	<EventLeafName>event</EventLeafName>
+	<RunLeafName>run</RunLeafName>
+	<SubRunLeafName>subrun</SubRunLeafName>
+	<UnixTimeLeafName>unix_ts</UnixTimeLeafName>
+	<StartTimeLeafName>event_start_t</StartTimeLeafName>
+	<EndTimeLeafName>event_end_t</EndTimeLeafName>
+	<MCIdLeafName>mcp_id</MCIdLeafName>
+	<MCLocalIdLeafName>mcp_idLocal</MCLocalIdLeafName>
+	<EventsToSkip>0</EventsToSkip>
+	<MinHitsToSkip>2</MinHitsToSkip>
+	<CaloHitListName>CaloHitList2D</CaloHitListName>
+	<PfoListName>RecreatedPfos</PfoListName>
+        <AnalysisFileName>LArRecoND.root</AnalysisFileName>
+        <AnalysisTreeName>LArRecoND</AnalysisTreeName>
+        <FoldToPrimaries>false</FoldToPrimaries>
+        <FoldToLeadingShowers>false</FoldToLeadingShowers>
+	<FoldDynamic>true</FoldDynamic>
+        <MinPurity>0.5</MinPurity>
+        <MinCompleteness>0.1</MinCompleteness>
+        <MinRecoHits>15</MinRecoHits>
+        <MinRecoHitsPerView>5</MinRecoHitsPerView>
+        <MinRecoGoodViews>2</MinRecoGoodViews>
+        <RemoveRecoNeutrons>true</RemoveRecoNeutrons>
+	<SelectRecoHits>true</SelectRecoHits>
+    </algorithm>
+
+</pandora>
+

--- a/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
@@ -19,6 +19,7 @@
         <NuSettingsFile>PandoraSettings_Neutrino_ThreeD_Cheated.xml</NuSettingsFile>
         <SlicingSettingsFile>PandoraSettings_Slicing_ThreeD_Cheated.xml</SlicingSettingsFile>
         <ShouldRunRockMus_Xworkers>true</ShouldRunRockMus_Xworkers>
+        <TagRockMuons>true</TagRockMuons>
         <StitchingTools>
           <tool type = "LArStitchingCosmicRayMerging">
             <ThreeDStitchingMode>true</ThreeDStitchingMode>
@@ -29,10 +30,13 @@
             <MinNCaloHits3D>10</MinNCaloHits3D>
           </tool>
         </StitchingTools>
+        <CosmicRayTaggingTools>
+            <tool type = "LArCosmicRayTagging">
+	      <CutMode>cautious</CutMode>
+	    </tool>
+        </CosmicRayTaggingTools>
 	<RockMuonTaggingTools>
 	  <tool type = "LArRockMuonTagging">
-	    <CutMode>cautious</CutMode>
-	    <TagRockMuons>true</TagRockMuons>
 	    <MarginX>5</MarginX>
 	    <MarginY>5</MarginY>
 	    <MarginZ>5</MarginZ>

--- a/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
@@ -56,10 +56,10 @@
     </algorithm>
 
     <!-- Gianfranco comment : debugging algorithm  -->
-    <algorithm type = "LArPrintCurrentPfoInfo">
-      <InputStageName>LArMasterThreeD</InputStageName>
-      <InputPfoListNames>RecreatedPfos</InputPfoListNames>
-    </algorithm>
+    <!-- <algorithm type = "LArPrintCurrentPfoInfo"> -->
+    <!--   <InputStageName>LArMasterThreeD</InputStageName> -->
+    <!--   <InputPfoListNames>RecreatedPfos</InputPfoListNames> -->
+    <!-- </algorithm> -->
 
     <algorithm type = "LArHierarchyAnalysis">
       <EventFileName>/exp/dune/app/users/ingratta/tests/rockmu_tagging_efficiency_NDLAr/data/MiniProdN5p1_Flow2Root_April2026/CONVERTED/MiniProdN5p1_NDComplex_FHC.flow2root.full.sanddrift.0000710.FLOW.hdf5_hits.root</EventFileName>

--- a/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
@@ -14,6 +14,13 @@
         <CurrentCaloHitListReplacement>CaloHitList2D</CurrentCaloHitListReplacement>
     </algorithm>
 
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <algorithm type = "LArPrintCurrentPfoInfo">
+      <InputStageName>LArPreProcessingThreeD</InputStageName>
+      <MCParticleListNames>Input</MCParticleListNames>
+      <!-- <InputHitListName>Input</InputHitListName> -->
+    </algorithm>
+
     <algorithm type = "LArMasterThreeD">
         <CRSettingsFile>PandoraSettings_Cosmic_Standard_ThreeD.xml</CRSettingsFile>
         <NuSettingsFile>PandoraSettings_Neutrino_ThreeD_Cheated.xml</NuSettingsFile>
@@ -62,8 +69,7 @@
     <!-- </algorithm> -->
 
     <algorithm type = "LArHierarchyAnalysis">
-      <EventFileName>/exp/dune/app/users/ingratta/tests/rockmu_tagging_efficiency_NDLAr/data/MiniProdN5p1_Flow2Root_April2026/CONVERTED/MiniProdN5p1_NDComplex_FHC.flow2root.full.sanddrift.0000710.FLOW.hdf5_hits.root</EventFileName>
-        <!-- <EventFileName>MicroProdN3p4_NDLAr_2E18_FHC.flow.geomfix.singles.nu.v251016.0000010.FLOW.hdf5_hits.root</EventFileName> -->
+        <EventFileName>LArRecoNDInput.root</EventFileName>
 	<EventTreeName>events</EventTreeName>
 	<EventLeafName>event</EventLeafName>
 	<RunLeafName>run</RunLeafName>

--- a/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
@@ -56,7 +56,7 @@
     </algorithm>
 
     <algorithm type = "LArHierarchyAnalysis">
-      <EventFileName>/exp/dune/app/users/ingratta/tests/evaluate_z_stitching_metrics_w_cheatingWorkflow_on_2x2_simu/CONVERTED/MiniRun6.4_1E19_RHC.flow.0000000.FLOW.hdf5_hits.root</EventFileName>
+      <EventFileName>/exp/dune/app/users/ingratta/tests/rockmu_tagging_efficiency_NDLAr/data/MiniProdN5p1_Flow2Root_April2026/MiniProdN5p1_NDComplex_FHC.flow2root.full.sanddrift.0000710.FLOW.hdf5_hits.root</EventFileName>
         <!-- <EventFileName>MicroProdN3p4_NDLAr_2E18_FHC.flow.geomfix.singles.nu.v251016.0000010.FLOW.hdf5_hits.root</EventFileName> -->
 	<EventTreeName>events</EventTreeName>
 	<EventLeafName>event</EventLeafName>

--- a/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
@@ -15,7 +15,7 @@
     </algorithm>
 
     <algorithm type = "LArMasterThreeD">
-        <CRSettingsFile>PandoraSettings_Cosmic_Standard_ThreeD_cheated.xml</CRSettingsFile>
+        <CRSettingsFile>PandoraSettings_Cosmic_Standard_ThreeD.xml</CRSettingsFile>
         <NuSettingsFile>PandoraSettings_Neutrino_ThreeD_Cheated.xml</NuSettingsFile>
         <SlicingSettingsFile>PandoraSettings_Slicing_ThreeD_Cheated.xml</SlicingSettingsFile>
         <ShouldRunRockMus_Xworkers>true</ShouldRunRockMus_Xworkers>
@@ -55,6 +55,12 @@
         <ShouldRemoveOutOfTimeHits>false</ShouldRemoveOutOfTimeHits>
     </algorithm>
 
+    <!-- Gianfranco comment : debugging algorithm  -->
+    <algorithm type = "LArPrintCurrentPfoInfo">
+      <InputStageName>LArMasterThreeD</InputStageName>
+      <InputPfoListNames>RecreatedPfos</InputPfoListNames>
+    </algorithm>
+
     <algorithm type = "LArHierarchyAnalysis">
       <EventFileName>/exp/dune/app/users/ingratta/tests/rockmu_tagging_efficiency_NDLAr/data/MiniProdN5p1_Flow2Root_April2026/CONVERTED/MiniProdN5p1_NDComplex_FHC.flow2root.full.sanddrift.0000710.FLOW.hdf5_hits.root</EventFileName>
         <!-- <EventFileName>MicroProdN3p4_NDLAr_2E18_FHC.flow.geomfix.singles.nu.v251016.0000010.FLOW.hdf5_hits.root</EventFileName> -->
@@ -73,9 +79,9 @@
 	<PfoListName>RecreatedPfos</PfoListName>
         <AnalysisFileName>LArRecoND.root</AnalysisFileName>
         <AnalysisTreeName>LArRecoND</AnalysisTreeName>
-        <FoldToPrimaries>false</FoldToPrimaries>
+        <FoldToPrimaries>true</FoldToPrimaries>
         <FoldToLeadingShowers>false</FoldToLeadingShowers>
-	<FoldDynamic>true</FoldDynamic>
+	<FoldDynamic>false</FoldDynamic>
         <MinPurity>0.5</MinPurity>
         <MinCompleteness>0.1</MinCompleteness>
         <MinRecoHits>15</MinRecoHits>

--- a/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD_cheated_w_rockmuTagging.xml
@@ -56,7 +56,7 @@
     </algorithm>
 
     <algorithm type = "LArHierarchyAnalysis">
-      <EventFileName>/exp/dune/app/users/ingratta/tests/rockmu_tagging_efficiency_NDLAr/data/MiniProdN5p1_Flow2Root_April2026/MiniProdN5p1_NDComplex_FHC.flow2root.full.sanddrift.0000710.FLOW.hdf5_hits.root</EventFileName>
+      <EventFileName>/exp/dune/app/users/ingratta/tests/rockmu_tagging_efficiency_NDLAr/data/MiniProdN5p1_Flow2Root_April2026/CONVERTED/MiniProdN5p1_NDComplex_FHC.flow2root.full.sanddrift.0000710.FLOW.hdf5_hits.root</EventFileName>
         <!-- <EventFileName>MicroProdN3p4_NDLAr_2E18_FHC.flow.geomfix.singles.nu.v251016.0000010.FLOW.hdf5_hits.root</EventFileName> -->
 	<EventTreeName>events</EventTreeName>
 	<EventLeafName>event</EventLeafName>

--- a/src/HierarchyAnalysisAlgorithm.cc
+++ b/src/HierarchyAnalysisAlgorithm.cc
@@ -15,6 +15,7 @@
 
 #include "TFile.h"
 #include "TTree.h"
+#include <algorithm>
 
 using namespace pandora;
 
@@ -107,7 +108,7 @@ StatusCode HierarchyAnalysisAlgorithm::Run()
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pMCParticleList));
     const PfoList *pPfoList(nullptr);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_pfoListName, pPfoList));
-
+    
     LArHierarchyHelper::FoldingParameters foldParameters;
     if (m_foldToPrimaries)
         foldParameters.m_foldToTier = true;
@@ -185,7 +186,7 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
     // Slice & cluster IDs, and number of hits
     IntVector sliceIdVect, clusterIdVect, n3DHitsVect, nUHitsVect, nVHitsVect, nWHitsVect;
     // Cluster isShower, isRecoPrimary & reco PDG hypothesis, as well as the track score
-    IntVector isShowerVect, isRecoPrimaryVect, recoPDGVect;
+    IntVector isShowerVect, isClearRockOrCosmicVect, isRecoPrimaryVect, recoPDGVect;
     FloatVector trackScoreVect;
     // Reco neutrino vertex
     FloatVector nuVtxXVect, nuVtxYVect, nuVtxZVect;
@@ -341,6 +342,12 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
                 const int isShower = (trackScore >= m_minTrackScore) ? 0 : 1;
                 isShowerVect.emplace_back(isShower);
 
+                // is clear rock/cosmic
+                const auto &props = pPfo->GetPropertiesMap();
+                auto it = props.find("IsClearCosmic");
+                const int isClearRockOrCosmic = (it != props.end()) ? it->second : 0;
+                isClearRockOrCosmicVect.emplace_back(isClearRockOrCosmic);
+
                 // Set reco PDG hypothesis, e.g track = muon, shower = electron.
                 // Since all PFOs are tracks for now, this will always be muon
                 const int recoPDG = (isShower == 0) ? MU_MINUS : E_MINUS;
@@ -488,6 +495,7 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "nVHits", &nVHitsVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "nWHits", &nWHitsVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "isShower", &isShowerVect));
+    PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "isClearRockOrCosmic", &isClearRockOrCosmicVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "trackScore", &trackScoreVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "recoPDG", &recoPDGVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "isRecoPrimary", &isRecoPrimaryVect));

--- a/src/LArNDContent.cc
+++ b/src/LArNDContent.cc
@@ -50,7 +50,8 @@
     d("LArEventSlicingThreeD",                  EventSlicingThreeDTool)                                                            \
     d("LArCheatingEventSlicingThreeD",          CheatingEventSlicingThreeDTool)                                                    \
     d("LArCheatingStitching",                   CheatingStitchingTool)                                                             \
-    d("LArCheatingRockMuonTagging",             CheatingRockMuonTaggingTool)
+    d("LArCheatingRockMuonTagging",             CheatingRockMuonTaggingTool)                                                       \
+    d("LArRockMuonTagging",             RockMuonTaggingTool)
 
 #define FACTORY Factory
 

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -43,8 +43,9 @@ StatusCode MasterThreeDAlgorithm::Run()
 
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->Reset());
 
+    WorkerToLArTPCMap workerToLArTPCMap;
     if (!m_workerInstancesInitialized)
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->InitializeWorkerInstances());
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->InitializeWorkerInstances(workerToLArTPCMap));
 
     if (m_passMCParticlesToWorkerInstances)
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CopyMCParticles());
@@ -55,7 +56,7 @@ StatusCode MasterThreeDAlgorithm::Run()
 
     if (m_shouldRunAllHitsCosmicReco)
     {
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RunCosmicRayReconstruction(volumeIdToHitListMap));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RunCosmicRayReconstruction(volumeIdToHitListMap, workerToLArTPCMap));
 
         PfoToLArTPCMap pfoToLArTPCMap;
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RecreateCosmicRayPfos(pfoToLArTPCMap));
@@ -343,11 +344,10 @@ const Pandora *MasterThreeDAlgorithm::CreateWorkerInstance(
         parentMaxZ = std::max(parentMaxZ, pLArTPC->GetCenterZ() + 0.5f * pLArTPC->GetWidthZ());
     }
 
-    if (m_shouldRunRockMus_Xworkers)
-        std::cout << "building a columnar drift volume with boundaries X = (" << parentMinX << ", " << parentMaxX 
-                                                               << ") , Y = (" << parentMinY << ", " << parentMaxY 
-                                                               << ") , Z = (" << parentMinZ << ", " << parentMaxZ 
-                                                               << ")\n";
+    std::cout << "Creating worker instance " << name <<" with boundaries X = (" << parentMinX << ", " << parentMaxX 
+                                                                 << ") , Y = (" << parentMinY << ", " << parentMaxY 
+                                                                 << ") , Z = (" << parentMinZ << ", " << parentMaxZ 
+                                                                 << ")\n";
     PandoraApi::Geometry::LArTPC::Parameters larTPCParameters;
     larTPCParameters.m_larTPCVolumeId = id;
     larTPCParameters.m_centerX = 0.5f * (parentMaxX + parentMinX);
@@ -390,7 +390,7 @@ const Pandora *MasterThreeDAlgorithm::CreateWorkerInstance(
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode MasterThreeDAlgorithm::InitializeWorkerInstances()
+StatusCode MasterThreeDAlgorithm::InitializeWorkerInstances(WorkerToLArTPCMap& workerToLArTPCMap)
 {
     // ATTN Used to be in the regular Initialize callback, but detector gap list cannot be extracted in client app before the first event
     if (m_workerInstancesInitialized)
@@ -431,6 +431,11 @@ StatusCode MasterThreeDAlgorithm::InitializeWorkerInstances()
             m_crWorkerInstances.push_back(
               this->CreateWorkerInstance(submap, gapList, m_crSettingsFile, "CRWorkerInstance" + std::to_string(worker_id), worker_id));
             worker_id++;
+
+            // loop over the group of TPCs along the same XY 
+            // and fill the map worker <---> vector<TPCs>
+            for (const LArTPCMap::value_type &mapEntry: submap)
+              workerToLArTPCMap[worker_id].push_back(mapEntry.second); 
            }
         }
         else
@@ -440,6 +445,8 @@ StatusCode MasterThreeDAlgorithm::InitializeWorkerInstances()
             const unsigned int volumeId(mapEntry.second->GetLArTPCVolumeId());
             m_crWorkerInstances.push_back(
                 this->CreateWorkerInstance(*(mapEntry.second), gapList, m_crSettingsFile, "CRWorkerInstance" + std::to_string(volumeId)));
+
+            workerToLArTPCMap[volumeId].push_back(mapEntry.second); 
           }
         }
 

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -37,6 +37,11 @@ using namespace pandora;
 namespace lar_content
 {
 
+MasterThreeDAlgorithm::MasterThreeDAlgorithm() :
+    m_shouldRunRockMus_Xworkers(false)
+  {
+  }
+
 StatusCode MasterThreeDAlgorithm::Run()
 {
     std::cout << "Should run slicing? " << m_shouldRunSlicing << std::endl;
@@ -121,6 +126,69 @@ StatusCode MasterThreeDAlgorithm::RunCosmicRayReconstruction(const VolumeIdToHit
     return STATUS_CODE_SUCCESS;
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
+StatusCode MasterThreeDAlgorithm::TagCosmicRayPfos(const PfoToFloatMap &stitchedPfosToX0Map, PfoList &clearCosmicRayPfos, PfoList &ambiguousPfos) const
+{
+    const PfoList *pRecreatedCRPfos(nullptr);
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::GetCurrentPfoList(this->GetPandora(), pRecreatedCRPfos));
+
+
+    PfoList nonStitchedParentCosmicRayPfos;
+    for (const Pfo *const pPfo : *pRecreatedCRPfos)
+    {
+        if (!pPfo->GetParentPfoList().empty())
+            continue;
+
+
+        PfoToFloatMap::const_iterator pfoToX0Iter = stitchedPfosToX0Map.find(pPfo);
+        const float x0Shift((pfoToX0Iter != stitchedPfosToX0Map.end()) ? pfoToX0Iter->second : 0.f);
+        PfoList &targetList((std::fabs(x0Shift) > m_inTimeMaxX0) ? clearCosmicRayPfos : nonStitchedParentCosmicRayPfos);
+        targetList.push_back(pPfo);
+    }
+
+
+    for (CosmicRayTaggingBaseTool *const pCosmicRayTaggingTool : m_cosmicRayTaggingToolVector)
+    {
+      if (auto *pRockMuonTaggingTool = dynamic_cast<RockMuonTaggingTool *>(pCosmicRayTaggingTool))
+      {
+        pRockMuonTaggingTool->FindAmbiguousPfos(nonStitchedParentCosmicRayPfos, ambiguousPfos, this);
+      }
+      else
+      {
+        std::cout << "Unable to cast CosmicRayTaggingBaseTool into RockMuonTaggingTool \n";
+      }
+    }
+
+
+    for (const Pfo *const pPfo : nonStitchedParentCosmicRayPfos)
+    {
+        const bool isClearCosmic(ambiguousPfos.end() == std::find(ambiguousPfos.begin(), ambiguousPfos.end(), pPfo));
+
+
+        if (isClearCosmic)
+            clearCosmicRayPfos.push_back(pPfo);
+    }
+
+
+    for (const Pfo *const pPfo : *pRecreatedCRPfos)
+    {
+        const bool isClearCosmic(ambiguousPfos.end() == std::find(ambiguousPfos.begin(), ambiguousPfos.end(), pPfo));
+        PandoraContentApi::ParticleFlowObject::Metadata metadata;
+        metadata.m_propertiesToAdd["IsClearCosmic"] = (isClearCosmic ? 1.f : 0.f);
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*this, pPfo, metadata));
+    }
+
+
+    if (m_visualizeOverallRecoStatus)
+    {
+        PANDORA_MONITORING_API(VisualizeParticleFlowObjects(this->GetPandora(), &clearCosmicRayPfos, "ClearCRPfos", RED));
+        PANDORA_MONITORING_API(VisualizeParticleFlowObjects(this->GetPandora(), &ambiguousPfos, "AmbiguousCRPfos", BLUE));
+        PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+    }
+
+
+    return STATUS_CODE_SUCCESS;
+}
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode MasterThreeDAlgorithm::RunCosmicRayHitRemoval(const PfoList &ambiguousPfos) const
@@ -553,6 +621,8 @@ StatusCode MasterThreeDAlgorithm::GetVolumeIdToHitListMap(VolumeIdToHitListMap &
 
 StatusCode MasterThreeDAlgorithm::ReadSettings(const pandora::TiXmlHandle xmlHandle)
 {
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShouldRunRockMus_Xworkers", m_shouldRunRockMus_Xworkers)); 
+    
     return MasterAlgorithm::ReadSettings(xmlHandle);
 }
 

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -38,7 +38,8 @@ namespace lar_content
 {
 
 MasterThreeDAlgorithm::MasterThreeDAlgorithm() :
-    m_shouldRunRockMus_Xworkers(false)
+    m_shouldRunRockMus_Xworkers(false),
+    m_tagRockMuons(false)
   {
   }
 
@@ -74,6 +75,7 @@ StatusCode MasterThreeDAlgorithm::Run()
     {
         PfoList clearCosmicRayPfos, ambiguousPfos;
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->TagCosmicRayPfos(stitchedPfosToX0Map, clearCosmicRayPfos, ambiguousPfos));
+
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RunCosmicRayHitRemoval(ambiguousPfos));
     }
 
@@ -90,6 +92,50 @@ StatusCode MasterThreeDAlgorithm::Run()
     return STATUS_CODE_SUCCESS;
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
+StatusCode MasterThreeDAlgorithm::TagCosmicRayPfos(const PfoToFloatMap &stitchedPfosToX0Map, PfoList &clearCosmicRayPfos, PfoList &ambiguousPfos) const
+{
+
+  PfoList ambiguousPfos_wRock;
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, MasterAlgorithm::TagCosmicRayPfos(stitchedPfosToX0Map, clearCosmicRayPfos, ambiguousPfos_wRock));
+  
+  if (!m_tagRockMuons)
+  {
+    for (const Pfo *const pPfo : ambiguousPfos_wRock)
+      ambiguousPfos.push_back(pPfo);
+
+    return STATUS_CODE_SUCCESS;
+  }
+  
+  
+  for (RockMuonTaggingTool *const pRockMuonTaggingTool : m_rockMuonTaggingToolVector)
+          pRockMuonTaggingTool->FindAmbiguousPfos(ambiguousPfos_wRock, ambiguousPfos, this);
+
+  // filter ambiguousPfos form rocks
+
+  const PfoList *pRecreatedCRPfos(nullptr);
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::GetCurrentPfoList(this->GetPandora(), pRecreatedCRPfos));
+
+  for (const Pfo *const pPfo : *pRecreatedCRPfos)
+  {
+        const bool isClearRock(ambiguousPfos.end() == std::find(ambiguousPfos.begin(), ambiguousPfos.end(), pPfo));
+        PandoraContentApi::ParticleFlowObject::Metadata metadata;
+        metadata.m_propertiesToAdd["IsClearCosmic"] = (isClearRock ? 1.f : 0.f); // TODO maybe decouple labels? isClearRock, good for now
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*this, pPfo, metadata));
+
+        if(isClearRock)
+          clearCosmicRayPfos.push_back(pPfo);
+  }
+
+  if (m_visualizeOverallRecoStatus)
+  {
+     PANDORA_MONITORING_API(VisualizeParticleFlowObjects(this->GetPandora(), &clearCosmicRayPfos, "ClearCRPfos", RED));
+     PANDORA_MONITORING_API(VisualizeParticleFlowObjects(this->GetPandora(), &ambiguousPfos, "AmbiguousPfos", BLUE));
+     PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+  }
+
+  return STATUS_CODE_SUCCESS;
+}
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode MasterThreeDAlgorithm::RunCosmicRayReconstruction(const VolumeIdToHitListMap &volumeIdToHitListMap, WorkerToLArTPCMap& workerToLArTPCMap) const
@@ -127,57 +173,6 @@ StatusCode MasterThreeDAlgorithm::RunCosmicRayReconstruction(const VolumeIdToHit
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
-StatusCode MasterThreeDAlgorithm::TagCosmicRayPfos(const PfoToFloatMap &stitchedPfosToX0Map, PfoList &clearCosmicRayPfos, PfoList &ambiguousPfos) const
-{
-    const PfoList *pRecreatedCRPfos(nullptr);
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::GetCurrentPfoList(this->GetPandora(), pRecreatedCRPfos));
-
-
-    PfoList nonStitchedParentCosmicRayPfos;
-    for (const Pfo *const pPfo : *pRecreatedCRPfos)
-    {
-        if (!pPfo->GetParentPfoList().empty())
-            continue;
-
-
-        PfoToFloatMap::const_iterator pfoToX0Iter = stitchedPfosToX0Map.find(pPfo);
-        const float x0Shift((pfoToX0Iter != stitchedPfosToX0Map.end()) ? pfoToX0Iter->second : 0.f);
-        PfoList &targetList((std::fabs(x0Shift) > m_inTimeMaxX0) ? clearCosmicRayPfos : nonStitchedParentCosmicRayPfos);
-        targetList.push_back(pPfo);
-    }
-
-
-    for (RockMuonTaggingTool *const pRockMuonTaggingTool : m_rockMuonTaggingToolVector)
-      pRockMuonTaggingTool->FindAmbiguousPfos(nonStitchedParentCosmicRayPfos, ambiguousPfos, this);
-
-    for (const Pfo *const pPfo : nonStitchedParentCosmicRayPfos)
-    {
-        const bool isClearCosmic(ambiguousPfos.end() == std::find(ambiguousPfos.begin(), ambiguousPfos.end(), pPfo));
-
-        if (isClearCosmic)
-            clearCosmicRayPfos.push_back(pPfo);
-    }
-
-    for (const Pfo *const pPfo : *pRecreatedCRPfos)
-    {
-        const bool isClearCosmic(ambiguousPfos.end() == std::find(ambiguousPfos.begin(), ambiguousPfos.end(), pPfo));
-        PandoraContentApi::ParticleFlowObject::Metadata metadata;
-        metadata.m_propertiesToAdd["IsClearCosmic"] = (isClearCosmic ? 1.f : 0.f);
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*this, pPfo, metadata));
-    }
-
-    if (m_visualizeOverallRecoStatus)
-    {
-        PANDORA_MONITORING_API(VisualizeParticleFlowObjects(this->GetPandora(), &clearCosmicRayPfos, "ClearCRPfos", RED));
-        PANDORA_MONITORING_API(VisualizeParticleFlowObjects(this->GetPandora(), &ambiguousPfos, "AmbiguousCRPfos", BLUE));
-        PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
-    }
-
-
-    return STATUS_CODE_SUCCESS;
-}
-//------------------------------------------------------------------------------------------------------------------------------------------
-
 StatusCode MasterThreeDAlgorithm::RunCosmicRayHitRemoval(const PfoList &ambiguousPfos) const
 {
     PfoList allPfosToDelete;
@@ -609,6 +604,8 @@ StatusCode MasterThreeDAlgorithm::GetVolumeIdToHitListMap(VolumeIdToHitListMap &
 StatusCode MasterThreeDAlgorithm::ReadSettings(const pandora::TiXmlHandle xmlHandle)
 {
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShouldRunRockMus_Xworkers", m_shouldRunRockMus_Xworkers)); 
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TagRockMuons", m_tagRockMuons));
 
     if (m_shouldRunCosmicHitRemoval)
     {

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -148,20 +148,15 @@ StatusCode MasterThreeDAlgorithm::TagCosmicRayPfos(const PfoToFloatMap &stitched
 
 
     for (RockMuonTaggingTool *const pRockMuonTaggingTool : m_rockMuonTaggingToolVector)
-    {
       pRockMuonTaggingTool->FindAmbiguousPfos(nonStitchedParentCosmicRayPfos, ambiguousPfos, this);
-    }
-
 
     for (const Pfo *const pPfo : nonStitchedParentCosmicRayPfos)
     {
         const bool isClearCosmic(ambiguousPfos.end() == std::find(ambiguousPfos.begin(), ambiguousPfos.end(), pPfo));
 
-
         if (isClearCosmic)
             clearCosmicRayPfos.push_back(pPfo);
     }
-
 
     for (const Pfo *const pPfo : *pRecreatedCRPfos)
     {
@@ -170,7 +165,6 @@ StatusCode MasterThreeDAlgorithm::TagCosmicRayPfos(const PfoToFloatMap &stitched
         metadata.m_propertiesToAdd["IsClearCosmic"] = (isClearCosmic ? 1.f : 0.f);
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*this, pPfo, metadata));
     }
-
 
     if (m_visualizeOverallRecoStatus)
     {

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -300,7 +300,7 @@ const Pandora *MasterThreeDAlgorithm::CreateWorkerInstance(
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 const Pandora *MasterThreeDAlgorithm::CreateWorkerInstance(
-    const LArTPCMap &larTPCMap, const DetectorGapList &gapList, const std::string &settingsFile, const std::string &name) const
+    const LArTPCMap &larTPCMap, const DetectorGapList &gapList, const std::string &settingsFile, const std::string &name, const unsigned int id = 0) const
 {
     if (larTPCMap.empty())
     {
@@ -343,8 +343,13 @@ const Pandora *MasterThreeDAlgorithm::CreateWorkerInstance(
         parentMaxZ = std::max(parentMaxZ, pLArTPC->GetCenterZ() + 0.5f * pLArTPC->GetWidthZ());
     }
 
+    if (m_shouldRunRockMus_Xworkers)
+        std::cout << "building a columnar drift volume with boundaries X = (" << parentMinX << ", " << parentMaxX 
+                                                               << ") , Y = (" << parentMinY << ", " << parentMaxY 
+                                                               << ") , Z = (" << parentMinZ << ", " << parentMaxZ 
+                                                               << ")\n";
     PandoraApi::Geometry::LArTPC::Parameters larTPCParameters;
-    larTPCParameters.m_larTPCVolumeId = 0;
+    larTPCParameters.m_larTPCVolumeId = id;
     larTPCParameters.m_centerX = 0.5f * (parentMaxX + parentMinX);
     larTPCParameters.m_centerY = 0.5f * (parentMaxY + parentMinY);
     larTPCParameters.m_centerZ = 0.5f * (parentMaxZ + parentMinZ);
@@ -396,11 +401,46 @@ StatusCode MasterThreeDAlgorithm::InitializeWorkerInstances()
         const LArTPCMap &larTPCMap(this->GetPandora().GetGeometry()->GetLArTPCMap());
         const DetectorGapList &gapList(this->GetPandora().GetGeometry()->GetDetectorGapList());
 
-        for (const LArTPCMap::value_type &mapEntry : larTPCMap)
-        {
+        if (m_shouldRunRockMus_Xworkers)
+        { // group TPCs that share the same XY coordinates in a unique worker instance 
+           std::map<std::pair<float, float>, LArTPCMap> XYgrouped;
+           for (const LArTPCMap::value_type &mapEntry : larTPCMap)
+           {
+             const LArTPC& tpc(*(mapEntry.second));
+             auto key = std::make_pair(tpc.GetCenterX(), tpc.GetCenterY());
+             auto it = XYgrouped.find(key);
+
+             if (it != XYgrouped.end())
+             {
+                LArTPCMap& tpcMap = it->second;
+                unsigned int current_max_id = tpcMap.empty() ? 0 : tpcMap.rbegin()->first + 1; 
+                XYgrouped[key].emplace(current_max_id, &tpc);
+             }
+             else
+             {
+               XYgrouped[key].emplace(0, &tpc);
+             }
+           }
+           // now that we have grouped drift volumes along xy in a map
+           // (x, y) <------> (drift_volume_1, drift_volume_2, ...)
+           // create a worker instance for each group
+           unsigned int worker_id = 0;
+           for (const auto& [xy, submap] : XYgrouped)
+           {
+             // const auto& [x, y] = xy;
+            m_crWorkerInstances.push_back(
+              this->CreateWorkerInstance(submap, gapList, m_crSettingsFile, "CRWorkerInstance" + std::to_string(worker_id), worker_id));
+            worker_id++;
+           }
+        }
+        else
+        { // dafault: crate 1 worker instance per drift volume
+          for (const LArTPCMap::value_type &mapEntry : larTPCMap)
+          {
             const unsigned int volumeId(mapEntry.second->GetLArTPCVolumeId());
             m_crWorkerInstances.push_back(
                 this->CreateWorkerInstance(*(mapEntry.second), gapList, m_crSettingsFile, "CRWorkerInstance" + std::to_string(volumeId)));
+          }
         }
 
         if (m_shouldRunSlicing)

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -333,9 +333,11 @@ const Pandora *MasterThreeDAlgorithm::CreateWorkerInstance(
     float parentMinZ(pFirstLArTPC->GetCenterZ() - 0.5f * pFirstLArTPC->GetWidthZ());
     float parentMaxZ(pFirstLArTPC->GetCenterZ() + 0.5f * pFirstLArTPC->GetWidthZ());
 
+    std::vector<int> lof_tpcs = {};
     for (const LArTPCMap::value_type &mapEntry : larTPCMap)
     {
         const LArTPC *const pLArTPC(mapEntry.second);
+        lof_tpcs.push_back(pLArTPC->GetLArTPCVolumeId());
         parentMinX = std::min(parentMinX, pLArTPC->GetCenterX() - 0.5f * pLArTPC->GetWidthX());
         parentMaxX = std::max(parentMaxX, pLArTPC->GetCenterX() + 0.5f * pLArTPC->GetWidthX());
         parentMinY = std::min(parentMinY, pLArTPC->GetCenterY() - 0.5f * pLArTPC->GetWidthY());
@@ -347,7 +349,12 @@ const Pandora *MasterThreeDAlgorithm::CreateWorkerInstance(
     std::cout << "Creating worker instance " << name <<" with boundaries X = (" << parentMinX << ", " << parentMaxX 
                                                                  << ") , Y = (" << parentMinY << ", " << parentMaxY 
                                                                  << ") , Z = (" << parentMinZ << ", " << parentMaxZ 
-                                                                 << ")\n";
+                                                                 << ")";
+    std::cout << " worker's tpcs : ";
+    for (const int tpc_id : lof_tpcs)
+      std::cout << tpc_id <<",";
+    std::cout <<"\n";
+
     PandoraApi::Geometry::LArTPC::Parameters larTPCParameters;
     larTPCParameters.m_larTPCVolumeId = id;
     larTPCParameters.m_centerX = 0.5f * (parentMaxX + parentMinX);
@@ -430,12 +437,13 @@ StatusCode MasterThreeDAlgorithm::InitializeWorkerInstances(WorkerToLArTPCMap& w
              // const auto& [x, y] = xy;
             m_crWorkerInstances.push_back(
               this->CreateWorkerInstance(submap, gapList, m_crSettingsFile, "CRWorkerInstance" + std::to_string(worker_id), worker_id));
-            worker_id++;
 
             // loop over the group of TPCs along the same XY 
             // and fill the map worker <---> vector<TPCs>
             for (const LArTPCMap::value_type &mapEntry: submap)
               workerToLArTPCMap[worker_id].push_back(mapEntry.second); 
+
+            worker_id++;
            }
         }
         else

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -84,6 +84,43 @@ StatusCode MasterThreeDAlgorithm::Run()
 
     return STATUS_CODE_SUCCESS;
 }
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode MasterThreeDAlgorithm::RunCosmicRayReconstruction(const VolumeIdToHitListMap &volumeIdToHitListMap, WorkerToLArTPCMap& workerToLArTPCMap) const
+{
+    for (const Pandora *const pCRWorker : m_crWorkerInstances)
+    {
+        const LArTPC &worker_larTPC(pCRWorker->GetGeometry()->GetLArTPC());
+        const unsigned int worker_id = worker_larTPC.GetLArTPCVolumeId();
+        
+        // loop over worker's TPCs
+        for (const pandora::LArTPC * pLArTPC : workerToLArTPCMap[worker_id])
+        {
+          const unsigned int larTPC_id = (*pLArTPC).GetLArTPCVolumeId();
+
+          // get all TPC's hits
+          VolumeIdToHitListMap::const_iterator iter(volumeIdToHitListMap.find(larTPC_id));
+
+          if (volumeIdToHitListMap.end() == iter)
+            continue;
+
+          // copy hits into the worker
+          std::cout << "Copying " << iter->second.m_allHitList.size() << " hits from LArTPC " << larTPC_id << " to worker " << worker_id << "\n"; 
+          for (const CaloHit *const pCaloHit : iter->second.m_allHitList)
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->Copy(pCRWorker, pCaloHit));
+        }
+
+
+        if (m_printOverallRecoStatus)
+            std::cout << "Running cosmic-ray reconstruction worker instance " << worker_id << " of " << m_crWorkerInstances.size() << std::endl;
+
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::ProcessEvent(*pCRWorker));
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode MasterThreeDAlgorithm::RunCosmicRayHitRemoval(const PfoList &ambiguousPfos) const

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -147,16 +147,9 @@ StatusCode MasterThreeDAlgorithm::TagCosmicRayPfos(const PfoToFloatMap &stitched
     }
 
 
-    for (CosmicRayTaggingBaseTool *const pCosmicRayTaggingTool : m_cosmicRayTaggingToolVector)
+    for (RockMuonTaggingTool *const pRockMuonTaggingTool : m_rockMuonTaggingToolVector)
     {
-      if (auto *pRockMuonTaggingTool = dynamic_cast<RockMuonTaggingTool *>(pCosmicRayTaggingTool))
-      {
-        pRockMuonTaggingTool->FindAmbiguousPfos(nonStitchedParentCosmicRayPfos, ambiguousPfos, this);
-      }
-      else
-      {
-        std::cout << "Unable to cast CosmicRayTaggingBaseTool into RockMuonTaggingTool \n";
-      }
+      pRockMuonTaggingTool->FindAmbiguousPfos(nonStitchedParentCosmicRayPfos, ambiguousPfos, this);
     }
 
 
@@ -622,6 +615,21 @@ StatusCode MasterThreeDAlgorithm::GetVolumeIdToHitListMap(VolumeIdToHitListMap &
 StatusCode MasterThreeDAlgorithm::ReadSettings(const pandora::TiXmlHandle xmlHandle)
 {
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShouldRunRockMus_Xworkers", m_shouldRunRockMus_Xworkers)); 
+
+    if (m_shouldRunCosmicHitRemoval)
+    {
+      AlgorithmToolVector algorithmToolVector;
+      PANDORA_RETURN_RESULT_IF(
+            STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "RockMuonTaggingTools", algorithmToolVector));
+
+      for (AlgorithmTool *const pAlgorithmTool : algorithmToolVector)
+      {
+            RockMuonTaggingTool *const pRockMuonTaggingTool(dynamic_cast<RockMuonTaggingTool *>(pAlgorithmTool));
+            if (!pRockMuonTaggingTool)
+                return STATUS_CODE_INVALID_PARAMETER;
+            m_rockMuonTaggingToolVector.push_back(pRockMuonTaggingTool);
+      }
+    }
     
     return MasterAlgorithm::ReadSettings(xmlHandle);
 }

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -496,27 +496,37 @@ StatusCode MasterThreeDAlgorithm::InitializeWorkerInstances(WorkerToLArTPCMap& w
         const DetectorGapList &gapList(this->GetPandora().GetGeometry()->GetDetectorGapList());
 
         if (m_shouldRunRockMus_Xworkers)
-        { // group TPCs that share the same XY coordinates in a unique worker instance 
+        { 
+          // Group TPCs (proxy for drift volumes here) that share the same XY coordinates 
+          // in a unique "columnar" worker instance.
+          // In the next lines, a map with the following structure is created: 
+          // (x0, y0) <---> (0: drift_volume_z0, 1: drift_volume_z1, ...)
+          // (x1, y1) <---> (0: drift_volume_z0, 1: drift_volume_z1, ...)
+          // where (x, y) represents the shared coordinates of drift volumes in the same column.
+
            std::map<std::pair<float, float>, LArTPCMap> XYgrouped;
+           const unsigned int FIRST_TPC_ID = 0;
            for (const LArTPCMap::value_type &mapEntry : larTPCMap)
            {
              const LArTPC& tpc(*(mapEntry.second));
-             auto key = std::make_pair(tpc.GetCenterX(), tpc.GetCenterY());
-             auto it = XYgrouped.find(key);
+             auto key_xy = std::make_pair(tpc.GetCenterX(), tpc.GetCenterY());
+             auto it_tpcMap = XYgrouped.find(key_xy);
 
-             if (it != XYgrouped.end())
+             if (it_tpcMap != XYgrouped.end())
              {
-                LArTPCMap& tpcMap = it->second;
-                unsigned int current_max_id = tpcMap.empty() ? 0 : tpcMap.rbegin()->first + 1; 
-                XYgrouped[key].emplace(current_max_id, &tpc);
+                // get the current group of tpcs correspondint to key_xy
+                LArTPCMap& tpcMap = it_tpcMap->second; 
+                // get the tpc id of the most recent added tpc - the newest tpc 
+                // id is the most recent + 1
+                unsigned int current_max_id = tpcMap.empty() ? FIRST_TPC_ID : tpcMap.rbegin()->first + 1; 
+                XYgrouped[key_xy].emplace(current_max_id, &tpc);
              }
-             else
+             else // new column of tpcs
              {
-               XYgrouped[key].emplace(0, &tpc);
+               XYgrouped[key_xy].emplace(FIRST_TPC_ID, &tpc);
              }
            }
            // now that we have grouped drift volumes along xy in a map
-           // (x, y) <------> (drift_volume_1, drift_volume_2, ...)
            // create a worker instance for each group
            unsigned int worker_id = 0;
            for (const auto& [xy, submap] : XYgrouped)

--- a/src/RockMuonTaggingTool.cc
+++ b/src/RockMuonTaggingTool.cc
@@ -9,6 +9,7 @@
 #include "Pandora/AlgorithmHeaders.h"
 
 #include "larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h"
+#include <memory>
 
 #include "RockMuonTaggingTool.h"
 
@@ -18,7 +19,6 @@ namespace lar_content
 {
 
 RockMuonTaggingTool::RockMuonTaggingTool() :
-    m_tagRockMuons(false),
     m_marginX(5.f), // [cm]
     m_marginY(5.f),
     m_marginZ(5.f)
@@ -45,49 +45,25 @@ bool RockMuonTaggingTool::IsOutsideBox(const float x, const float y, const float
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
-void RockMuonTaggingTool::CheckIfThroughgoing(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsThroughgoingMap) const
+bool RockMuonTaggingTool::CheckIfThroughgoing(const CRCandidate& candidate) const
 {
-    for (const CRCandidate &candidate : candidates)
-    {
-      bool isThroughgoing = (
-          (candidate.m_endPoint1.GetX() != std::numeric_limits<float>::max()) && // for some reason some candidates happen to have "default" values set as inf 
+      return (
+          (candidate.m_endPoint1.GetX() != std::numeric_limits<float>::max()) && // candidates whose sliding fit fails, have default values set as inf 
           IsOutsideBox(candidate.m_endPoint1.GetX(), candidate.m_endPoint1.GetY(), candidate.m_endPoint1.GetZ()) &&
-          IsOutsideBox(candidate.m_endPoint2.GetX(), candidate.m_endPoint2.GetY(), candidate.m_endPoint2.GetZ()));
-
-      if (!pfoToIsThroughgoingMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, isThroughgoing)).second)
-        throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
-    }
+          IsOutsideBox(candidate.m_endPoint2.GetX(), candidate.m_endPoint2.GetY(), candidate.m_endPoint2.GetZ())
+          );
 } 
 
-//------------------------------------------------------------------------------------------------------------------------------------------
-void RockMuonTaggingTool::TagRockMuons(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsLikelyRockMuonMap, const PfoToBoolMap &pfoToIsThroughgoingMap) const
-{
-    int nof_tagged_rockmus = 0;
-    for (const CRCandidate &candidate : candidates)
-    {
-	bool likelyRockMuon = false;
-
-        if(m_tagRockMuons && (pfoToIsThroughgoingMap.at(candidate.m_pPfo)))
-        {
-          likelyRockMuon = true;
-          nof_tagged_rockmus++;
-        }
-
-	if (!pfoToIsLikelyRockMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyRockMuon)).second)
-          throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
-    }
-    std::cout << "nof tagged rock muons : " << nof_tagged_rockmus << "\n";
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-void RockMuonTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos, PfoList &ambiguousPfos, const MasterAlgorithm *const /*pAlgorithm*/)
+//----------------------------------------------------- -------------------------------------------------------------------------------------
+void RockMuonTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos, PfoList &ambiguousPfos,  const MasterAlgorithm *const /*pAlgorithm*/)
 {
     if (this->GetPandora().GetSettings()->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
-    // TODO First time only, TODO Refactor with master algorithm
+    // TODO to Refactored in LAr Content. Good for now
     const LArTPCMap &larTPCMap(this->GetPandora().GetGeometry()->GetLArTPCMap());
     const LArTPC *const pFirstLArTPC(larTPCMap.begin()->second);
+
 
     float parentMinX(pFirstLArTPC->GetCenterX() - 0.5f * pFirstLArTPC->GetWidthX());
     float parentMaxX(pFirstLArTPC->GetCenterX() + 0.5f * pFirstLArTPC->GetWidthX());
@@ -95,6 +71,7 @@ void RockMuonTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos, 
     float parentMaxY(pFirstLArTPC->GetCenterY() + 0.5f * pFirstLArTPC->GetWidthY());
     float parentMinZ(pFirstLArTPC->GetCenterZ() - 0.5f * pFirstLArTPC->GetWidthZ());
     float parentMaxZ(pFirstLArTPC->GetCenterZ() + 0.5f * pFirstLArTPC->GetWidthZ());
+
 
     for (const LArTPCMap::value_type &mapEntry : larTPCMap)
     {
@@ -113,105 +90,45 @@ void RockMuonTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos, 
     m_face_Yt = parentMaxY;
     m_face_Zu = parentMinZ;
     m_face_Zd = parentMaxZ;
-    
-    if(m_tagRockMuons)
-     std::cout << "Detector boundaries to tag rock muons : x [" 
-               << m_face_Xa + m_marginX <<"," << m_face_Xc - m_marginX<< "] "
-               << "y [" << m_face_Yb + m_marginY <<"," << m_face_Yt - m_marginY<< "] "
-               << "z [" << m_face_Zu + m_marginZ <<"," << m_face_Zd - m_marginZ << "] \n";
+    // end refactoring here
 
-    PfoToPfoListMap pfoAssociationMap;
-    this->GetPfoAssociations(parentCosmicRayPfos, pfoAssociationMap);
+    std::cout << "Detector boundaries to tag clear rock muons : " 
+               << "x [" << m_face_Xa + m_marginX << "," << m_face_Xc - m_marginX << "] "
+               << "y [" << m_face_Yb + m_marginY << "," << m_face_Yt - m_marginY << "] "
+               << "z [" << m_face_Zu + m_marginZ << "," << m_face_Zd - m_marginZ << "] \n";
 
-    PfoToSliceIdMap pfoToSliceIdMap;
-    this->SliceEvent(parentCosmicRayPfos, pfoAssociationMap, pfoToSliceIdMap);
+    int nof_tagged_rockmus = 0;
 
-    CRCandidateList candidates;
-    this->GetCRCandidates(parentCosmicRayPfos, pfoToSliceIdMap, candidates);
-
-    PfoToBoolMap pfoToInTimeMap;
-    this->CheckIfInTime(candidates, pfoToInTimeMap);
-
-    PfoToBoolMap pfoToIsContainedMap;
-    this->CheckIfContained(candidates, pfoToIsContainedMap);
-
-    PfoToBoolMap pfoToIsTopToBottomMap;
-    this->CheckIfTopToBottom(candidates, pfoToIsTopToBottomMap);
-
-    UIntSet neutrinoSliceSet;
-    this->GetNeutrinoSlices(candidates, pfoToInTimeMap, pfoToIsContainedMap, neutrinoSliceSet);
-
-    PfoToBoolMap pfoToIsLikelyCRMuonMap;
-    this->TagCRMuons(candidates, pfoToInTimeMap, pfoToIsTopToBottomMap, neutrinoSliceSet, pfoToIsLikelyCRMuonMap);
-
-    // (clear) rock muon tagging
-    PfoToBoolMap pfoToIsLikelyRockMuonMap;
-    if(m_tagRockMuons)
-    {
-      PfoToBoolMap pfoToIsThroughgoingMap;
-      this->CheckIfThroughgoing(candidates, pfoToIsThroughgoingMap);
-
-      this->TagRockMuons(candidates, pfoToIsLikelyRockMuonMap, pfoToIsThroughgoingMap);
-    }
-    // end rock muon tagging
-
+    // Filter out left over rock muons in the ambigious Pfos list....
     for (const ParticleFlowObject *const pPfo : parentCosmicRayPfos)
     {
-        const bool is_rock = pfoToIsLikelyRockMuonMap.at(pPfo); // dummy-proof (for me, basically) 
-        const bool is_cosmic = pfoToIsLikelyCRMuonMap.at(pPfo); 
+        const CRCandidate candidate = CRCandidate(this->GetPandora(), pPfo, 0);
+        // Note: 0 is a placeholder for pfoSliceId (unused in CheckIfThroughGoing).
+        // CRCandidate is used (instead of pfo) because it runs sliding and gives track start/stop.
 
-        if(m_tagRockMuons)
+        const bool is_thorughgoing = this->CheckIfThroughgoing(candidate);
+        
+        if(!is_thorughgoing)
         {
-          if (!(is_rock || is_cosmic))
-            ambiguousPfos.push_back(pPfo);
+          // clean this clear rock mu from ambiguousPfos
+          ambiguousPfos.push_back(pPfo);
         }
         else
         {
-          if (!is_cosmic)
-            ambiguousPfos.push_back(pPfo);
+          nof_tagged_rockmus++;
         }
     }
+    
+    std::cout << "nof tagged rock muons : " << nof_tagged_rockmus << "\n";
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 StatusCode RockMuonTaggingTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CutMode", m_cutMode));
-    std::transform(m_cutMode.begin(), m_cutMode.end(), m_cutMode.begin(), ::tolower);
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "AngularUncertainty", m_angularUncertainty));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PositionalUncertainty", m_positionalUncertainty));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAssociationDist", m_maxAssociationDist));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "HitThreshold", m_minimumHits));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InTimeMargin", m_inTimeMargin));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InTimeMaxX0", m_inTimeMaxX0));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TagRockMuons", m_tagRockMuons));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginX", m_marginX));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginY", m_marginY));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginZ", m_marginZ));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxNeutrinoCosTheta", m_maxNeutrinoCosTheta));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCosmicCosTheta", m_minCosmicCosTheta));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxCosmicCurvature", m_maxCosmicCurvature));
-
-    return STATUS_CODE_SUCCESS;
+    return CosmicRayTaggingTool::ReadSettings(xmlHandle);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/RockMuonTaggingTool.cc
+++ b/src/RockMuonTaggingTool.cc
@@ -157,12 +157,17 @@ void RockMuonTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos, 
 
     for (const ParticleFlowObject *const pPfo : parentCosmicRayPfos)
     {
-        if (!pfoToIsLikelyCRMuonMap.at(pPfo))
-            ambiguousPfos.push_back(pPfo);
+        const bool is_rock = pfoToIsLikelyRockMuonMap.at(pPfo); // dummy-proof (for me, basically) 
+        const bool is_cosmic = pfoToIsLikelyCRMuonMap.at(pPfo); 
 
         if(m_tagRockMuons)
         {
-          if (!pfoToIsLikelyRockMuonMap.at(pPfo))
+          if (!(is_rock || is_cosmic))
+            ambiguousPfos.push_back(pPfo);
+        }
+        else
+        {
+          if (!is_cosmic)
             ambiguousPfos.push_back(pPfo);
         }
     }

--- a/src/RockMuonTaggingTool.cc
+++ b/src/RockMuonTaggingTool.cc
@@ -1,0 +1,207 @@
+/**
+ *  @file   src/RockMuonTaggingTool.cc
+ *
+ *  @brief  Implementation of the rock muon tagging tool class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h"
+
+#include "RockMuonTaggingTool.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+RockMuonTaggingTool::RockMuonTaggingTool() :
+    m_tagRockMuons(true),
+    m_marginX(5.f), // [cm]
+    m_marginY(5.f),
+    m_marginZ(5.f)
+  {
+  }
+
+bool RockMuonTaggingTool::IsOutsideBox(const float x, const float y, const float z) const 
+{
+  const float BoxXmin = m_face_Xa + m_marginX;
+  const float BoxXmax = m_face_Xc - m_marginX;
+
+  const float BoxYmin = m_face_Yb + m_marginY;
+  const float BoxYmax = m_face_Yt - m_marginY;
+
+  const float BoxZmin = m_face_Zu + m_marginZ;
+  const float BoxZmax = m_face_Zd - m_marginZ;
+
+  bool IsOutRangeX = (x < BoxXmin || x > BoxXmax);
+  bool IsOutRangeY = (y < BoxYmin || y > BoxYmax);
+  bool IsOutRangeZ = (z < BoxZmin || z > BoxZmax);
+
+  return (IsOutRangeZ || IsOutRangeY || IsOutRangeX);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+void RockMuonTaggingTool::CheckIfThroughgoing(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsThroughgoingMap) const
+{
+    for (const CRCandidate &candidate : candidates)
+    {
+      bool isThroughgoing = (
+          (candidate.m_endPoint1.GetX() != std::numeric_limits<float>::max()) && // for some reason some candidates happen to have "default" values set as inf 
+          IsOutsideBox(candidate.m_endPoint1.GetX(), candidate.m_endPoint1.GetY(), candidate.m_endPoint1.GetZ()) &&
+          IsOutsideBox(candidate.m_endPoint2.GetX(), candidate.m_endPoint2.GetY(), candidate.m_endPoint2.GetZ()));
+
+      if (!pfoToIsThroughgoingMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, isThroughgoing)).second)
+        throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+    }
+} 
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+void RockMuonTaggingTool::TagRockMuons(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsLikelyRockMuonMap, const PfoToBoolMap &pfoToIsThroughgoingMap) const
+{
+    for (const CRCandidate &candidate : candidates)
+    {
+	bool likelyRockMuon = false;
+
+        if(m_tagRockMuons && (pfoToIsThroughgoingMap.at(candidate.m_pPfo)))
+          likelyRockMuon = true;
+
+	if (!pfoToIsLikelyRockMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyRockMuon)).second)
+          throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+void RockMuonTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos, PfoList &ambiguousPfos, const MasterAlgorithm *const /*pAlgorithm*/)
+{
+    if (this->GetPandora().GetSettings()->ShouldDisplayAlgorithmInfo())
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+
+    // TODO First time only, TODO Refactor with master algorithm
+    const LArTPCMap &larTPCMap(this->GetPandora().GetGeometry()->GetLArTPCMap());
+    const LArTPC *const pFirstLArTPC(larTPCMap.begin()->second);
+
+    float parentMinX(pFirstLArTPC->GetCenterX() - 0.5f * pFirstLArTPC->GetWidthX());
+    float parentMaxX(pFirstLArTPC->GetCenterX() + 0.5f * pFirstLArTPC->GetWidthX());
+    float parentMinY(pFirstLArTPC->GetCenterY() - 0.5f * pFirstLArTPC->GetWidthY());
+    float parentMaxY(pFirstLArTPC->GetCenterY() + 0.5f * pFirstLArTPC->GetWidthY());
+    float parentMinZ(pFirstLArTPC->GetCenterZ() - 0.5f * pFirstLArTPC->GetWidthZ());
+    float parentMaxZ(pFirstLArTPC->GetCenterZ() + 0.5f * pFirstLArTPC->GetWidthZ());
+
+    for (const LArTPCMap::value_type &mapEntry : larTPCMap)
+    {
+        const LArTPC *const pLArTPC(mapEntry.second);
+        parentMinX = std::min(parentMinX, pLArTPC->GetCenterX() - 0.5f * pLArTPC->GetWidthX());
+        parentMaxX = std::max(parentMaxX, pLArTPC->GetCenterX() + 0.5f * pLArTPC->GetWidthX());
+        parentMinY = std::min(parentMinY, pLArTPC->GetCenterY() - 0.5f * pLArTPC->GetWidthY());
+        parentMaxY = std::max(parentMaxY, pLArTPC->GetCenterY() + 0.5f * pLArTPC->GetWidthY());
+        parentMinZ = std::min(parentMinZ, pLArTPC->GetCenterZ() - 0.5f * pLArTPC->GetWidthZ());
+        parentMaxZ = std::max(parentMaxZ, pLArTPC->GetCenterZ() + 0.5f * pLArTPC->GetWidthZ());
+    }
+
+    m_face_Xa = parentMinX;
+    m_face_Xc = parentMaxX;
+    m_face_Yb = parentMinY;
+    m_face_Yt = parentMaxY;
+    m_face_Zu = parentMinZ;
+    m_face_Zd = parentMaxZ;
+    
+    if(m_tagRockMuons)
+     std::cout << "Detector boundaries to tag rock muons : x [" 
+               << m_face_Xa + m_marginX <<"," << m_face_Xc - m_marginX<< "] "
+               << "y [" << m_face_Yb + m_marginY <<"," << m_face_Yt - m_marginY<< "] "
+               << "z [" << m_face_Zu + m_marginZ <<"," << m_face_Zd - m_marginZ << "] \n";
+
+    PfoToPfoListMap pfoAssociationMap;
+    this->GetPfoAssociations(parentCosmicRayPfos, pfoAssociationMap);
+
+    PfoToSliceIdMap pfoToSliceIdMap;
+    this->SliceEvent(parentCosmicRayPfos, pfoAssociationMap, pfoToSliceIdMap);
+
+    CRCandidateList candidates;
+    this->GetCRCandidates(parentCosmicRayPfos, pfoToSliceIdMap, candidates);
+
+    PfoToBoolMap pfoToInTimeMap;
+    this->CheckIfInTime(candidates, pfoToInTimeMap);
+
+    PfoToBoolMap pfoToIsContainedMap;
+    this->CheckIfContained(candidates, pfoToIsContainedMap);
+
+    PfoToBoolMap pfoToIsTopToBottomMap;
+    this->CheckIfTopToBottom(candidates, pfoToIsTopToBottomMap);
+
+    UIntSet neutrinoSliceSet;
+    this->GetNeutrinoSlices(candidates, pfoToInTimeMap, pfoToIsContainedMap, neutrinoSliceSet);
+
+    PfoToBoolMap pfoToIsLikelyCRMuonMap;
+    this->TagCRMuons(candidates, pfoToInTimeMap, pfoToIsTopToBottomMap, neutrinoSliceSet, pfoToIsLikelyCRMuonMap);
+
+    // (clear) rock muon tagging
+    PfoToBoolMap pfoToIsLikelyRockMuonMap;
+    if(m_tagRockMuons)
+    {
+      PfoToBoolMap pfoToIsThroughgoingMap;
+      this->CheckIfThroughgoing(candidates, pfoToIsThroughgoingMap);
+
+      this->TagRockMuons(candidates, pfoToIsLikelyRockMuonMap, pfoToIsThroughgoingMap);
+    }
+    // end rock muon tagging
+
+    for (const ParticleFlowObject *const pPfo : parentCosmicRayPfos)
+    {
+        if (!pfoToIsLikelyCRMuonMap.at(pPfo))
+            ambiguousPfos.push_back(pPfo);
+
+        if(m_tagRockMuons)
+        {
+          if (!pfoToIsLikelyRockMuonMap.at(pPfo))
+            ambiguousPfos.push_back(pPfo);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+StatusCode RockMuonTaggingTool::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CutMode", m_cutMode));
+    std::transform(m_cutMode.begin(), m_cutMode.end(), m_cutMode.begin(), ::tolower);
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "AngularUncertainty", m_angularUncertainty));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PositionalUncertainty", m_positionalUncertainty));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAssociationDist", m_maxAssociationDist));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "HitThreshold", m_minimumHits));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InTimeMargin", m_inTimeMargin));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InTimeMaxX0", m_inTimeMaxX0));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TagRockMuons", m_tagRockMuons));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginX", m_marginX));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginY", m_marginY));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginZ", m_marginZ));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxNeutrinoCosTheta", m_maxNeutrinoCosTheta));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCosmicCosTheta", m_minCosmicCosTheta));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxCosmicCurvature", m_maxCosmicCurvature));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+} // namespace lar_content

--- a/src/RockMuonTaggingTool.cc
+++ b/src/RockMuonTaggingTool.cc
@@ -18,13 +18,14 @@ namespace lar_content
 {
 
 RockMuonTaggingTool::RockMuonTaggingTool() :
-    m_tagRockMuons(true),
+    m_tagRockMuons(false),
     m_marginX(5.f), // [cm]
     m_marginY(5.f),
     m_marginZ(5.f)
   {
   }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
 bool RockMuonTaggingTool::IsOutsideBox(const float x, const float y, const float z) const 
 {
   const float BoxXmin = m_face_Xa + m_marginX;
@@ -61,16 +62,21 @@ void RockMuonTaggingTool::CheckIfThroughgoing(const CRCandidateList &candidates,
 //------------------------------------------------------------------------------------------------------------------------------------------
 void RockMuonTaggingTool::TagRockMuons(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsLikelyRockMuonMap, const PfoToBoolMap &pfoToIsThroughgoingMap) const
 {
+    int nof_tagged_rockmus = 0;
     for (const CRCandidate &candidate : candidates)
     {
 	bool likelyRockMuon = false;
 
         if(m_tagRockMuons && (pfoToIsThroughgoingMap.at(candidate.m_pPfo)))
+        {
           likelyRockMuon = true;
+          nof_tagged_rockmus++;
+        }
 
 	if (!pfoToIsLikelyRockMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyRockMuon)).second)
           throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
     }
+    std::cout << "nof tagged rock muons : " << nof_tagged_rockmus << "\n";
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/RockMuonTaggingTool.cc
+++ b/src/RockMuonTaggingTool.cc
@@ -37,9 +37,9 @@ bool RockMuonTaggingTool::IsOutsideBox(const float x, const float y, const float
   const float BoxZmin = m_face_Zu + m_marginZ;
   const float BoxZmax = m_face_Zd - m_marginZ;
 
-  bool IsOutRangeX = (x < BoxXmin || x > BoxXmax);
-  bool IsOutRangeY = (y < BoxYmin || y > BoxYmax);
-  bool IsOutRangeZ = (z < BoxZmin || z > BoxZmax);
+  const bool IsOutRangeX = (x < BoxXmin || x > BoxXmax);
+  const bool IsOutRangeY = (y < BoxYmin || y > BoxYmax);
+  const bool IsOutRangeZ = (z < BoxZmin || z > BoxZmax);
 
   return (IsOutRangeZ || IsOutRangeY || IsOutRangeX);
 }
@@ -106,9 +106,9 @@ void RockMuonTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos, 
         // Note: 0 is a placeholder for pfoSliceId (unused in CheckIfThroughGoing).
         // CRCandidate is used (instead of pfo) because it runs sliding and gives track start/stop.
 
-        const bool is_thorughgoing = this->CheckIfThroughgoing(candidate);
+        const bool is_throughgoing = this->CheckIfThroughgoing(candidate);
         
-        if(!is_thorughgoing)
+        if(!is_throughgoing)
         {
           // clean this clear rock mu from ambiguousPfos
           ambiguousPfos.push_back(pPfo);

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -384,7 +384,18 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
             const pandora::CartesianVector voxelPos(voxelX, voxelY, voxelZ);
             const float MipE{0.00075};
             const float voxelMipEquivalentE = voxelE / MipE;
-            const int tpcID(voxel_io_group);
+            // TEMPORARY COMMENT: if we read the tpcID from input voxel_io_group
+            // do we actually need to keep the 'geom' input? For now use it as 
+            // fallback option in case voxel_io_group for any reason in null
+            int tpcID = -1; 
+            if (voxel_io_group < 0)
+            {
+              tpcID = geom.GetTPCNumber(voxelPos);
+            }
+            else 
+            {
+              tpcID = voxel_io_group;
+            }
             lar_content::LArCaloHitParameters caloHitParameters;
             caloHitParameters.m_positionVector = voxelPos;
             caloHitParameters.m_expectedDirection = pandora::CartesianVector(0.f, 0.f, 1.f);

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -371,6 +371,7 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
             const float voxelY = (*larsp->m_y)[isp];
             const float voxelZ = (*larsp->m_z)[isp];
             const float voxelE = (*larsp->m_charge)[isp];
+            const int voxel_io_group = (*larsp->m_io_group)[isp];
 
             // Skip this hit if its coordinates or energy are NaNs
             if (std::isnan(voxelX) || std::isnan(voxelY) || std::isnan(voxelZ) || std::isnan(voxelE))
@@ -383,7 +384,7 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
             const pandora::CartesianVector voxelPos(voxelX, voxelY, voxelZ);
             const float MipE{0.00075};
             const float voxelMipEquivalentE = voxelE / MipE;
-            const int tpcID(geom.GetTPCNumber(voxelPos));
+            const int tpcID(voxel_io_group);
             lar_content::LArCaloHitParameters caloHitParameters;
             caloHitParameters.m_positionVector = voxelPos;
             caloHitParameters.m_expectedDirection = pandora::CartesianVector(0.f, 0.f, 1.f);

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -253,7 +253,7 @@ void MakePandoraTPC(const pandora::Pandora *const pPrimaryPandora, const Paramet
 
         geom.AddTPC(centreX - dx, centreX + dx, centreY - dy, centreY + dy, centreZ - dz, centreZ + dz, tpcNumber);
 
-        std::cout << "Creating TPC: " << centreX - dx << ", " << centreX + dx << ", " << centreY - dy << ", " << centreY + dy << ", "
+        std::cout << "Creating TPC "<<tpcNumber << ": " << centreX - dx << ", " << centreX + dx << ", " << centreY - dy << ", " << centreY + dy << ", "
                   << centreZ - dz << ", " << centreZ + dz << std::endl;
     }
     catch (const pandora::StatusCodeException &)
@@ -394,7 +394,7 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
             }
             else 
             {
-              tpcID = voxel_io_group;
+              tpcID = ioGroup2tcpIDMap_2x2[voxel_io_group];
             }
             lar_content::LArCaloHitParameters caloHitParameters;
             caloHitParameters.m_positionVector = voxelPos;

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -394,7 +394,9 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
             }
             else 
             {
-              tpcID = ioGroup2tcpIDMap_2x2[voxel_io_group];
+              // TODO : how do we handle this?
+              // tpcID = ioGroup2tcpIDMap_2x2[voxel_io_group];
+              tpcID = ioGroup2tcpIDMap_NDLAr(voxel_io_group);
             }
             lar_content::LArCaloHitParameters caloHitParameters;
             caloHitParameters.m_positionVector = voxelPos;

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -384,20 +384,24 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
             const pandora::CartesianVector voxelPos(voxelX, voxelY, voxelZ);
             const float MipE{0.00075};
             const float voxelMipEquivalentE = voxelE / MipE;
+
             // TEMPORARY COMMENT: if we read the tpcID from input voxel_io_group
             // do we actually need to keep the 'geom' input? For now use it as 
             // fallback option in case voxel_io_group for any reason in null
             int tpcID = -1; 
-            if (voxel_io_group < 0)
+            if ((70 == geom.m_TPCs.size()) && (voxel_io_group >= 0)) // NDLAr
+            {
+              tpcID = ioGroup2tcpIDMap_NDLAr(voxel_io_group);
+            } 
+            else if ((4 == geom.m_TPCs.size()) && (voxel_io_group >= 0)) // 2x2 
+            {
+              tpcID = ioGroup2tcpIDMap_2x2[voxel_io_group];
+            } 
+            else 
             {
               tpcID = geom.GetTPCNumber(voxelPos);
             }
-            else 
-            {
-              // TODO : how do we handle this?
-              // tpcID = ioGroup2tcpIDMap_2x2[voxel_io_group];
-              tpcID = ioGroup2tcpIDMap_NDLAr(voxel_io_group);
-            }
+
             lar_content::LArCaloHitParameters caloHitParameters;
             caloHitParameters.m_positionVector = voxelPos;
             caloHitParameters.m_expectedDirection = pandora::CartesianVector(0.f, 0.f, 1.f);

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -397,6 +397,10 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
             {
               tpcID = ioGroup2tcpIDMap_2x2[voxel_io_group];
             } 
+            else if ((2 == geom.m_TPCs.size()) && (voxel_io_group >= 0)) // FSD
+            {
+              tpcID = ioGroup2tcpIDMap_FSD[voxel_io_group];
+            }
             else 
             {
               tpcID = geom.GetTPCNumber(voxelPos);


### PR DESCRIPTION
Start this PR to implement rock muon tagging using X stitching only. The proposed approach here is an alternative to the earlier proposed method of combining Z and X stitching which is in PRs [PR#46 LArRecoND](https://github.com/PandoraPFA/LArRecoND/pull/46) + [PR#257 LArContent](https://github.com/PandoraPFA/LArContent/pull/257).

Putting here a couple of slides for a more extensive explanation
[rockmu_cosmic3d_columnar_workers.pdf](https://github.com/user-attachments/files/26226246/rockmu_cosmic3d_columnar_workers.pdf)
