### PR TITLE
General Updates

### DIFF
--- a/include/MasterThreeDAlgorithm.h
+++ b/include/MasterThreeDAlgorithm.h
@@ -37,6 +37,22 @@ protected:
     pandora::StatusCode Run() override;
 
     /**
+     *  @brief  Copy mc particles in the named input list to the given pandora instance.
+     *
+     *  @param  pPandora the pandora instance to which to copy the mc particles
+     */
+    pandora::StatusCode CopyMCParticles(const pandora::Pandora *pPandora) const;
+
+
+    /**
+     * @brief  Run cosmic-ray reconstruction, then recreate the resulting pfos in the current pandora instance.
+     *
+     * @param  volumeIdToHitListMap the LArTPC Volume ID to Hit List Map
+     * @param  pfoToLArTPCMap To receive the mapping from pfos
+     */
+    pandora::StatusCode RunCosmicRayReconstructionThenRecreate(const VolumeIdToHitListMap &volumeIdToHitListMap, PfoToLArTPCMap &pfoToLArTPCMap) const;
+
+    /**
      *  @brief  Run cosmic-ray hit removal, freeing hits in ambiguous pfos for further processing
      *
      *  @param  ambiguousPfos the list of ambiguous cosmic-ray pfos

--- a/include/PandoraInterface.h
+++ b/include/PandoraInterface.h
@@ -180,6 +180,15 @@ void MakePandoraTPC(const pandora::Pandora *const pPrimaryPandora, const Paramet
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 /**
+ *  @brief  Create and register all the detector gaps in Pandora, based on the loaded geometry.
+ *
+ *  @param  pPrimaryPandora The address of the primary pandora instance
+ */
+void LoadDetectorGaps(const pandora::Pandora *const pPrimaryPandora);
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+/**
  *  @brief  Process events using the supplied pandora instance
  *
  *  @param  parameters The application parameters

--- a/settings/PandoraSettings_Neutrino_ThreeD_DLVtx.xml
+++ b/settings/PandoraSettings_Neutrino_ThreeD_DLVtx.xml
@@ -139,6 +139,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -158,6 +159,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -169,6 +171,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>
@@ -204,6 +207,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <ShowerTools>
             <tool type = "LArClearShowers"/>
             <tool type = "LArSplitShowers"/>
@@ -217,6 +221,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -236,6 +241,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -247,6 +253,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>

--- a/settings/PandoraSettings_Neutrino_ThreeD_Merged.xml
+++ b/settings/PandoraSettings_Neutrino_ThreeD_Merged.xml
@@ -129,6 +129,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -148,6 +149,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -159,6 +161,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>
@@ -173,7 +176,7 @@
 <!--        <MaxShowerLengthCut>500.</MaxShowerLengthCut> -->
         <VertexDistanceRatioCut>500.</VertexDistanceRatioCut>
         <SlidingFitWindow>10</SlidingFitWindow>
-        <ShowerWidthRatioCut>2.0</ShowerWidthRatioCut> 
+        <ShowerWidthRatioCut>2.0</ShowerWidthRatioCut>
     </algorithm>
     <algorithm type = "LArListDeletion">
         <PfoListNames>ShowerParticles3D</PfoListNames>
@@ -194,6 +197,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <ShowerTools>
             <tool type = "LArClearShowers"/>
             <tool type = "LArSplitShowers"/>
@@ -207,6 +211,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -226,6 +231,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -237,6 +243,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>
@@ -306,7 +313,7 @@
         <DaughterListNames>ClustersU ClustersV ClustersW</DaughterListNames>
         <AddHitsAsIsolated>true</AddHitsAsIsolated>
     </algorithm>
-    
+
     <algorithm type = "LArBdtPfoCharacterisation">
         <TrackPfoListName>TrackParticles3D</TrackPfoListName>
         <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>

--- a/settings/PandoraSettings_Slicing_ThreeD.xml
+++ b/settings/PandoraSettings_Slicing_ThreeD.xml
@@ -85,6 +85,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -104,6 +105,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -115,6 +117,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>
@@ -150,6 +153,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <ShowerTools>
             <tool type = "LArClearShowers"/>
             <tool type = "LArSplitShowers"/>
@@ -167,6 +171,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -186,6 +191,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -197,6 +203,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>

--- a/settings/PandoraSettings_Slicing_ThreeD_Merged.xml
+++ b/settings/PandoraSettings_Slicing_ThreeD_Merged.xml
@@ -91,6 +91,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -110,6 +111,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -121,6 +123,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>
@@ -153,6 +156,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <ShowerTools>
             <tool type = "LArClearShowers"/>
             <tool type = "LArSplitShowers"/>
@@ -166,6 +170,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -185,6 +190,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -196,6 +202,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -27,6 +27,7 @@
 #include "larpandoracontent/LArPlugins/LArRotationalTransformationPlugin.h"
 
 #include "larpandoracontent/LArUtility/PfoMopUpBaseAlgorithm.h"
+#include <larpandoracontent/LArControlFlow/MasterAlgorithm.h>
 
 #ifdef LIBTORCH_DL
 #include "larpandoradlcontent/LArDLContent.h"
@@ -46,19 +47,14 @@ StatusCode MasterThreeDAlgorithm::Run()
     if (!m_workerInstancesInitialized)
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->InitializeWorkerInstances());
 
-    if (m_passMCParticlesToWorkerInstances)
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CopyMCParticles());
-
     PfoToFloatMap stitchedPfosToX0Map;
     VolumeIdToHitListMap volumeIdToHitListMap;
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetVolumeIdToHitListMap(volumeIdToHitListMap));
 
     if (m_shouldRunAllHitsCosmicReco)
     {
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RunCosmicRayReconstruction(volumeIdToHitListMap));
-
         PfoToLArTPCMap pfoToLArTPCMap;
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RecreateCosmicRayPfos(pfoToLArTPCMap));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RunCosmicRayReconstructionThenRecreate(volumeIdToHitListMap, pfoToLArTPCMap));
 
         if (m_shouldRunStitching)
             PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->StitchCosmicRayPfos(pfoToLArTPCMap, stitchedPfosToX0Map));
@@ -76,6 +72,9 @@ StatusCode MasterThreeDAlgorithm::Run()
 
     if (m_shouldRunNeutrinoRecoOption || m_shouldRunCosmicRecoOption)
     {
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CopyMCParticles(m_pSliceNuWorkerInstance));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CopyMCParticles(m_pSliceCRWorkerInstance));
+
         SliceHypotheses nuSliceHypotheses, crSliceHypotheses;
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RunSliceReconstruction(sliceVector, nuSliceHypotheses, crSliceHypotheses));
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->SelectBestSliceHypotheses(nuSliceHypotheses, crSliceHypotheses));
@@ -83,6 +82,23 @@ StatusCode MasterThreeDAlgorithm::Run()
 
     return STATUS_CODE_SUCCESS;
 }
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode MasterThreeDAlgorithm::CopyMCParticles(const Pandora *pPandora) const
+{
+    if (!m_passMCParticlesToWorkerInstances)
+        return STATUS_CODE_SUCCESS;
+
+    const MCParticleList *pMCParticleList(nullptr);
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_inputMCParticleListName, pMCParticleList));
+    LArMCParticleFactory mcParticleFactory;
+
+    for (const MCParticle *const pMCParticle : *pMCParticleList)
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->Copy(pPandora, pMCParticle, &mcParticleFactory));
+
+    return STATUS_CODE_SUCCESS;
+}
+
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode MasterThreeDAlgorithm::RunCosmicRayHitRemoval(const PfoList &ambiguousPfos) const
@@ -126,6 +142,44 @@ StatusCode MasterThreeDAlgorithm::RunCosmicRayHitRemoval(const PfoList &ambiguou
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+StatusCode MasterThreeDAlgorithm::RunCosmicRayReconstructionThenRecreate(const VolumeIdToHitListMap &volumeIdToHitListMap, PfoToLArTPCMap &pfoToLArTPCMap) const
+{
+    unsigned int workerCounter(0);
+
+    for (const Pandora *const pCRWorker : m_crWorkerInstances)
+    {
+        const LArTPC &larTPC(pCRWorker->GetGeometry()->GetLArTPC());
+        VolumeIdToHitListMap::const_iterator iter(volumeIdToHitListMap.find(larTPC.GetLArTPCVolumeId()));
+
+        if (volumeIdToHitListMap.end() == iter)
+            continue;
+
+        for (const CaloHit *const pCaloHit : iter->second.m_allHitList)
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->Copy(pCRWorker, pCaloHit));
+
+        if (m_printOverallRecoStatus)
+            std::cout << "Running cosmic-ray reconstruction worker instance " << ++workerCounter << " of " << m_crWorkerInstances.size() << std::endl;
+
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CopyMCParticles(pCRWorker));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::ProcessEvent(*pCRWorker));
+
+        const PfoList *pCRPfos(nullptr);
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::GetCurrentPfoList(*pCRWorker, pCRPfos));
+
+        PfoList newPfoList;
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, MasterAlgorithm::Recreate(*pCRPfos, newPfoList));
+
+        for (const Pfo *const pNewPfo : newPfoList)
+            pfoToLArTPCMap[pNewPfo] = &larTPC;
+
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::Reset(*pCRWorker));
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 StatusCode MasterThreeDAlgorithm::RunSlicing(const VolumeIdToHitListMap &volumeIdToHitListMap, SliceVector &sliceVector) const
 {
     std::cout << "There are " << volumeIdToHitListMap.size() << " volumes" << std::endl;
@@ -156,6 +210,7 @@ StatusCode MasterThreeDAlgorithm::RunSlicing(const VolumeIdToHitListMap &volumeI
             std::cout << "Running slicing worker instance" << std::endl;
 
         const PfoList *pSlicePfos(nullptr);
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CopyMCParticles(m_pSlicingWorkerInstance));
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::ProcessEvent(*m_pSlicingWorkerInstance));
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::GetCurrentPfoList(*m_pSlicingWorkerInstance, pSlicePfos));
 

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -486,6 +486,7 @@ StatusCode MasterThreeDAlgorithm::GetVolumeIdToHitListMap(VolumeIdToHitListMap &
 
     const CaloHitList *pCaloHitList(nullptr);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_inputHitListName, pCaloHitList));
+    std::map<HitType, std::pair<unsigned int, unsigned int>> hitTypeToStatusMap;
 
     for (const CaloHit *const pCaloHit : *pCaloHitList)
     {
@@ -504,11 +505,18 @@ StatusCode MasterThreeDAlgorithm::GetVolumeIdToHitListMap(VolumeIdToHitListMap &
                 (pCaloHit->GetPositionVector().GetX() <= (pLArTPC->GetCenterX() + 0.5f * pLArTPC->GetWidthX()))))
         {
             larTPCHitList.m_truncatedHitList.push_back(pCaloHit);
+            hitTypeToStatusMap[pCaloHit->GetHitType()].first++;
         }
         else
-            std::cout << "Hit of type " << pCaloHit->GetHitType() << " outside TPC " << volumeId << "? "
-                      << pCaloHit->GetPositionVector().GetX() << ", " << pLArTPC->GetCenterX() - 0.5f * pLArTPC->GetWidthX() << ", "
-                      << pLArTPC->GetCenterX() + 0.5f * pLArTPC->GetWidthX() << std::endl;
+            hitTypeToStatusMap[pCaloHit->GetHitType()].second++;
+    }
+
+    for (const auto &hitTypeToStatusMapEntry : hitTypeToStatusMap)
+    {
+        const HitType hitType(hitTypeToStatusMapEntry.first);
+        const unsigned int nInTimeHits(hitTypeToStatusMapEntry.second.first);
+        const unsigned int nOutOfTimeHits(hitTypeToStatusMapEntry.second.second);
+        std::cout << "Hit type " << hitType << ": " << nInTimeHits << " hits in TPC, " << nOutOfTimeHits << " hits outside of the TPC" << std::endl;
     }
 
     return STATUS_CODE_SUCCESS;

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -14,6 +14,7 @@
 #include "TGeoMatrix.h"
 #include "TGeoShape.h"
 #include "TGeoVolume.h"
+#include <regex>
 
 #ifdef USE_EDEPSIM
 #include "TG4PrimaryVertex.h"
@@ -361,6 +362,29 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
             LArSPMC *larspmc = dynamic_cast<LArSPMC *>(larsp.get());
             CreateSPMCParticles(*larspmc, pPrimaryPandora, parameters);
         }
+
+        // And event level information...
+        int run{0};
+        int subrun{0};
+        const int event{larsp->m_event};
+
+        // INFO: Currently, the run + subrun fields are seemingly not set in the
+        // input ROOT files, so we can instead parse it from the input file
+        // name, if possible.
+        //
+        // This should pull out 12 from
+        // MiniProdN5p1_NDComplex_FHC.flow.full.sanddrift.0000012.FLOW.hdf5_hits.root
+        std::regex fileNameRegex(".*\\.(\\d+)\\.FLOW.*");
+        std::smatch matches;
+
+        if (std::regex_match(parameters.m_inputFileName, matches, fileNameRegex) && matches.size() > 1)
+        {
+            run = std::stoi(matches[1].str());
+            subrun = run;
+        }
+
+        std::cout << "Event info: run " << run << ", subrun " << subrun << ", event " << event << std::endl;
+        PandoraApi::SetEventInformation(*pPrimaryPandora, run, subrun, event);
 
         int hitCounter(0);
 

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -428,7 +428,7 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
             caloHitParameters.m_hitRegion = pandora::SINGLE_REGION;
             caloHitParameters.m_layer = 0;
             caloHitParameters.m_isInOuterSamplingLayer = false;
-            caloHitParameters.m_pParentAddress = (void *)(static_cast<uintptr_t>(++hitCounter));
+            caloHitParameters.m_pParentAddress = (void *)(static_cast<uintptr_t>(hitCounter));
             caloHitParameters.m_larTPCVolumeId = tpcID < 0 ? 0 : tpcID;
             caloHitParameters.m_daughterVolumeId = 0;
 
@@ -473,7 +473,7 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
                 // U view
                 lar_content::LArCaloHitParameters caloHitPars_UView(caloHitParameters);
                 caloHitPars_UView.m_hitType = pandora::TPC_VIEW_U;
-                caloHitPars_UView.m_pParentAddress = (void *)(intptr_t(++hitCounter));
+                caloHitPars_UView.m_pParentAddress = (void *)(intptr_t(hitCounter));
                 const float upos_cm(pPrimaryPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoU(y0_cm, z0_cm));
                 caloHitPars_UView.m_positionVector = pandora::CartesianVector(x0_cm, 0.f, upos_cm);
 
@@ -486,7 +486,7 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
                 // V view
                 lar_content::LArCaloHitParameters caloHitPars_VView(caloHitParameters);
                 caloHitPars_VView.m_hitType = pandora::TPC_VIEW_V;
-                caloHitPars_VView.m_pParentAddress = (void *)(intptr_t(++hitCounter));
+                caloHitPars_VView.m_pParentAddress = (void *)(intptr_t(hitCounter));
                 const float vpos_cm(pPrimaryPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoV(y0_cm, z0_cm));
                 caloHitPars_VView.m_positionVector = pandora::CartesianVector(x0_cm, 0.f, vpos_cm);
                 PANDORA_THROW_RESULT_IF(
@@ -497,7 +497,7 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
                 // W view
                 lar_content::LArCaloHitParameters caloHitPars_WView(caloHitParameters);
                 caloHitPars_WView.m_hitType = pandora::TPC_VIEW_W;
-                caloHitPars_WView.m_pParentAddress = (void *)(intptr_t(++hitCounter));
+                caloHitPars_WView.m_pParentAddress = (void *)(intptr_t(hitCounter));
                 const float wpos_cm(pPrimaryPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoW(y0_cm, z0_cm));
                 caloHitPars_WView.m_positionVector = pandora::CartesianVector(x0_cm, 0.f, wpos_cm);
 
@@ -507,6 +507,9 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
                     PandoraApi::SetCaloHitToMCParticleRelationship(
                         *pPrimaryPandora, (void *)((intptr_t)hitCounter), (void *)((intptr_t)trackID), energyFrac);
             }
+
+            // Increment hit counter for unique Hit IDs
+            ++hitCounter;
 
         } // end space point loop
 

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -14,8 +14,6 @@
 #include "TGeoMatrix.h"
 #include "TGeoShape.h"
 #include "TGeoVolume.h"
-#include <Objects/CartesianVector.h>
-#include <regex>
 
 #ifdef USE_EDEPSIM
 #include "TG4PrimaryVertex.h"
@@ -55,6 +53,7 @@
 #include <iostream>
 #include <memory>
 #include <random>
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -102,7 +101,7 @@ int main(int argc, char *argv[])
             PandoraApi::SetLArTransformationPlugin(*pPrimaryPandora, new lar_content::LArRotationalTransformationPlugin));
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::ReadSettings(*pPrimaryPandora, parameters.m_settingsFile));
 
-        // INFO: Now tthat the geometry + transformation plugins are set up, we
+        // INFO: Now that the geometry + transformation plugins are set up, we
         // can create the detector gaps in Pandora based on the loaded geometry.
         LoadDetectorGaps(pPrimaryPandora);
 

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -14,6 +14,7 @@
 #include "TGeoMatrix.h"
 #include "TGeoShape.h"
 #include "TGeoVolume.h"
+#include <Objects/CartesianVector.h>
 #include <regex>
 
 #ifdef USE_EDEPSIM
@@ -100,6 +101,10 @@ int main(int argc, char *argv[])
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
             PandoraApi::SetLArTransformationPlugin(*pPrimaryPandora, new lar_content::LArRotationalTransformationPlugin));
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::ReadSettings(*pPrimaryPandora, parameters.m_settingsFile));
+
+        // INFO: Now tthat the geometry + transformation plugins are set up, we
+        // can create the detector gaps in Pandora based on the loaded geometry.
+        LoadDetectorGaps(pPrimaryPandora);
 
         ProcessEvents(parameters, pPrimaryPandora, simpleGeom);
     }
@@ -272,6 +277,119 @@ void MakePandoraTPC(const pandora::Pandora *const pPrimaryPandora, const Paramet
                      "invalid information supplied"
                   << std::endl;
     }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LoadDetectorGaps(const pandora::Pandora *const pPrimaryPandora)
+{
+    if (pPrimaryPandora->GetGeometry()->GetLArTPCMap().empty())
+    {
+        std::cout << "PandoraInterface::LoadDetectorGaps - no TPCs found in geometry, cannot create detector gaps" << std::endl;
+        return;
+    }
+
+    if (!pPrimaryPandora->GetGeometry()->GetDetectorGapList().empty())
+    {
+        std::cout << "PandoraInterface::LoadDetectorGaps - Detector gaps already exist in geometry, not adding any more" << std::endl;
+        return;
+    }
+
+    // Find the absolute bounds of the global detector, along with the unique X & Z boundaries.
+    float globalMinX(std::numeric_limits<float>::max());
+    float globalMaxX(std::numeric_limits<float>::lowest());
+    float globalMinY(std::numeric_limits<float>::max());
+    float globalMaxY(std::numeric_limits<float>::lowest());
+    float globalMinZ(std::numeric_limits<float>::max());
+    float globalMaxZ(std::numeric_limits<float>::lowest());
+
+    std::vector<float> minXs, maxXs, minZs, maxZs;
+
+    const auto &larTPCMap = pPrimaryPandora->GetGeometry()->GetLArTPCMap();
+    for (const auto &[id, larTPC] : larTPCMap)
+    {
+        const float halfX(0.5 * larTPC->GetWidthX());
+        const float halfY(0.5 * larTPC->GetWidthY());
+        const float halfZ(0.5 * larTPC->GetWidthZ());
+
+        minXs.push_back(larTPC->GetCenterX() - halfX);
+        maxXs.push_back(larTPC->GetCenterX() + halfX);
+        minZs.push_back(larTPC->GetCenterZ() - halfZ);
+        maxZs.push_back(larTPC->GetCenterZ() + halfZ);
+
+        globalMinX = std::min(globalMinX, larTPC->GetCenterX() - halfX);
+        globalMaxX = std::max(globalMaxX, larTPC->GetCenterX() + halfX);
+        globalMinY = std::min(globalMinY, larTPC->GetCenterY() - halfY);
+        globalMaxY = std::max(globalMaxY, larTPC->GetCenterY() + halfY);
+        globalMinZ = std::min(globalMinZ, larTPC->GetCenterZ() - halfZ);
+        globalMaxZ = std::max(globalMaxZ, larTPC->GetCenterZ() + halfZ);
+    }
+
+    // Sort and remove duplicated, within some tolerance.
+    auto extractUnique = [](std::vector<float> &vec)
+    {
+        std::sort(vec.begin(), vec.end());
+        vec.erase(std::unique(vec.begin(), vec.end(), [](float a, float b) { return std::fabs(a - b) < 0.1f; }), vec.end());
+    };
+
+    extractUnique(minXs);
+    extractUnique(maxXs);
+    extractUnique(minZs);
+    extractUnique(maxZs);
+
+    // Utility lambda to crate a 3D Box Gap
+    auto createBoxGap = [&](const float x1, const float x2, const float y1, const float y2, const float z1, const float z2)
+    {
+        PandoraApi::Geometry::BoxGap::Parameters gapParameters;
+        gapParameters.m_vertex = CartesianVector(x1, y1, z1);
+        gapParameters.m_side1 = CartesianVector(x2 - x1, 0.f, 0.f);
+        gapParameters.m_side2 = CartesianVector(0.f, y2 - y1, 0.f);
+        gapParameters.m_side3 = CartesianVector(0.f, 0.f, z2 - z1);
+
+        try
+        {
+            PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::BoxGap::Create(*pPrimaryPandora, gapParameters));
+        }
+        catch (...)
+        {
+            std::cout << "LoadDetectorGaps - unable to create detector gap, insufficient or invalid information supplied" << std::endl;
+        }
+
+        // TODO: Add in 2D projection code here!
+    };
+
+    // INFO: Build the gaps in 2 steps:
+    //       1) Gaps that go the full length in X
+    //       2) Gaps that segment Z, to prevent overlaps.
+    for (size_t i = 0; i < maxXs.size() && i + 1 < minXs.size(); ++i)
+    {
+        const float gapWidth(minXs[i + 1] - maxXs[i]);
+
+        // Skip negative gaps or giant gaps.
+        //
+        // TODO: Make max gap size configurable. Its mostly to avoid "Look there
+        // is a gap between TPCs 1 and 3!"....but its because TPC 2 is there.
+        if (gapWidth < 0.f || gapWidth > 30.f)
+            continue;
+
+        createBoxGap(minXs[i], maxXs[i + 1], globalMinY, globalMaxY, globalMinZ, globalMaxZ);
+    }
+
+    // Then, segmented Z gaps.
+    for (size_t iz = 0; iz < maxZs.size() && iz + 1 < minZs.size(); ++iz)
+    {
+        const float gapWidth(minZs[iz + 1] - maxZs[iz]);
+
+        // Skip negative gaps or giant gaps.
+        if (gapWidth < 0.f || gapWidth > 30.f)
+            continue;
+
+        for (size_t ix = 0; ix < minXs.size(); ++ix)
+            createBoxGap(minXs[ix], maxXs[ix], globalMinY, globalMaxY, minZs[iz + 1], maxZs[iz]);
+    }
+
+    std::cout << "PandoraInterface::LoadDetectorGaps - created " << pPrimaryPandora->GetGeometry()->GetDetectorGapList().size()
+              << " detector gaps" << std::endl;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -717,7 +835,7 @@ void ProcessEDepSimEvents(const Parameters &parameters, const Pandora *const pPr
         // Loop over (EDep) hits, which are stored in the hit segment detectors.
         // Only process hits from the detector we are interested in
         for (TG4HitSegmentDetectors::iterator detector = pEDepSimEvent->SegmentDetectors.begin();
-             detector != pEDepSimEvent->SegmentDetectors.end(); ++detector)
+            detector != pEDepSimEvent->SegmentDetectors.end(); ++detector)
         {
             if (detector->first.find(parameters.m_sensitiveDetName) == std::string::npos)
             {

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -358,7 +358,7 @@ void LoadDetectorGaps(const pandora::Pandora *const pPrimaryPandora)
 
 
     // Utility lambda to crate a 3D Box Gap
-    auto createBoxGap = [&](const float x1, const float x2, const float y1, const float y2, const float z1, const float z2)
+    auto createBoxGap = [&](const float x1, const float x2, const float y1, const float y2, const float z1, const float z2, const bool inductionGaps = false)
     {
         PandoraApi::Geometry::BoxGap::Parameters gapParameters;
         gapParameters.m_vertex = CartesianVector(x1, y1, z1);
@@ -375,13 +375,16 @@ void LoadDetectorGaps(const pandora::Pandora *const pPrimaryPandora)
             std::cout << "LoadDetectorGaps - unable to create detector gap, insufficient or invalid information supplied" << std::endl;
         }
 
-        // Project gap into U, V, and W LineGaps
+        // Project gap into W & UV if asked for.
+        const auto wCorners = {pTrans->YZtoW(y1,z1), pTrans->YZtoW(y1,z2), pTrans->YZtoW(y2,z1), pTrans->YZtoW(y2,z2)};
+        createLineGap(pandora::TPC_VIEW_W, x1, x2, std::min(wCorners), std::max(wCorners));
+
+        if (!inductionGaps) return;
+
         const auto uCorners = {pTrans->YZtoU(y1,z1), pTrans->YZtoU(y1,z2), pTrans->YZtoU(y2,z1), pTrans->YZtoU(y2,z2)};
         const auto vCorners = {pTrans->YZtoV(y1,z1), pTrans->YZtoV(y1,z2), pTrans->YZtoV(y2,z1), pTrans->YZtoV(y2,z2)};
-        const auto wCorners = {pTrans->YZtoW(y1,z1), pTrans->YZtoW(y1,z2), pTrans->YZtoW(y2,z1), pTrans->YZtoW(y2,z2)};
         createLineGap(pandora::TPC_VIEW_U, x1, x2, std::min(uCorners), std::max(uCorners));
         createLineGap(pandora::TPC_VIEW_V, x1, x2, std::min(vCorners), std::max(vCorners));
-        createLineGap(pandora::TPC_VIEW_W, x1, x2, std::min(wCorners), std::max(wCorners));
     };
 
     // INFO: Build the gaps in 2 steps:
@@ -398,7 +401,7 @@ void LoadDetectorGaps(const pandora::Pandora *const pPrimaryPandora)
         if (gapWidth < 0.f || gapWidth > 30.f)
             continue;
 
-        createBoxGap(minXs[i], maxXs[i + 1], globalMinY, globalMaxY, globalMinZ, globalMaxZ);
+        createBoxGap(minXs[i], maxXs[i + 1], globalMinY, globalMaxY, globalMinZ, globalMaxZ, true);
     }
 
     // Then, segmented Z gaps.
@@ -411,7 +414,7 @@ void LoadDetectorGaps(const pandora::Pandora *const pPrimaryPandora)
             continue;
 
         for (size_t ix = 0; ix < minXs.size(); ++ix)
-            createBoxGap(minXs[ix], maxXs[ix], globalMinY, globalMaxY, minZs[iz + 1], maxZs[iz]);
+            createBoxGap(minXs[ix], maxXs[ix], globalMinY, globalMaxY, minZs[iz + 1], maxZs[iz], false);
     }
 
     std::cout << "PandoraInterface::LoadDetectorGaps - created " << pPrimaryPandora->GetGeometry()->GetDetectorGapList().size()

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -336,6 +336,27 @@ void LoadDetectorGaps(const pandora::Pandora *const pPrimaryPandora)
     extractUnique(minZs);
     extractUnique(maxZs);
 
+    // Utility lambda to create a 2D LineGap
+    auto createLineGap = [&](const pandora::HitType view, const float startX, const float endX, const float startZ, const float endZ) {
+        PandoraApi::Geometry::LineGap::Parameters lineParams;
+        lineParams.m_lineGapType = view == pandora::TPC_VIEW_U ? LineGapType::TPC_WIRE_GAP_VIEW_U :
+                                    view == pandora::TPC_VIEW_V ? LineGapType::TPC_WIRE_GAP_VIEW_V :
+                                    view == pandora::TPC_VIEW_W ? LineGapType::TPC_WIRE_GAP_VIEW_W :
+                                                                    LineGapType::TPC_DRIFT_GAP;
+        lineParams.m_lineStartX = std::min(startX, endX);
+        lineParams.m_lineEndX = std::max(startX, endX);
+        lineParams.m_lineStartZ = std::min(startZ, endZ);
+        lineParams.m_lineEndZ = std::max(startZ, endZ);
+
+        try {
+            PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPrimaryPandora, lineParams));
+        } catch (...) {
+            std::cout << "LoadDetectorGaps - unable to create LineGap for view " << view << std::endl;
+        }
+    };
+
+
+
     // Utility lambda to crate a 3D Box Gap
     auto createBoxGap = [&](const float x1, const float x2, const float y1, const float y2, const float z1, const float z2)
     {
@@ -354,7 +375,13 @@ void LoadDetectorGaps(const pandora::Pandora *const pPrimaryPandora)
             std::cout << "LoadDetectorGaps - unable to create detector gap, insufficient or invalid information supplied" << std::endl;
         }
 
-        // TODO: Add in 2D projection code here!
+        // Project gap into U, V, and W LineGaps
+        const auto uCorners = {pTrans->YZtoU(y1,z1), pTrans->YZtoU(y1,z2), pTrans->YZtoU(y2,z1), pTrans->YZtoU(y2,z2)};
+        const auto vCorners = {pTrans->YZtoV(y1,z1), pTrans->YZtoV(y1,z2), pTrans->YZtoV(y2,z1), pTrans->YZtoV(y2,z2)};
+        const auto wCorners = {pTrans->YZtoW(y1,z1), pTrans->YZtoW(y1,z2), pTrans->YZtoW(y2,z1), pTrans->YZtoW(y2,z2)};
+        createLineGap(pandora::TPC_VIEW_U, x1, x2, std::min(uCorners), std::max(uCorners));
+        createLineGap(pandora::TPC_VIEW_V, x1, x2, std::min(vCorners), std::max(vCorners));
+        createLineGap(pandora::TPC_VIEW_W, x1, x2, std::min(wCorners), std::max(wCorners));
     };
 
     // INFO: Build the gaps in 2 steps:


### PR DESCRIPTION
Opening this as a draft, because there is some TODO notes, and bits to check...

This adds some of the infrastructure changes I've made recently, decoupled from the DL Slicing work.

### Worker Revamp

Currently, the top level workflow in the master algorithm is this:

 - Copy all MC to all workers
 - Run every Cosmic Worker
 - Process every Cosmic Worker
 - Run Slicing
 - Run Slice Reco

That is fairly wasteful though. All ~100-200,000 MC hits and what not are copied to 70 CR workers, and then just left there, ballooning the RAM usage.

I've swapped it to:

 - Copy MC to CR Worker 1, Run CR Worker 1, Process CR Worker 1, Reset CR Worker 1.
 - Repeat for all workers
 - Copy MC to Slicing Worker, Run Slicing
 - Copy MC to Slice Reco Workers, Run Slice Reco Workers

That gets things in much better control, without requiring larger changes. We still copy over all 100-200k hits to each worker when they will only need 1/70th of it...but that is a larger more involved change. Same for the slicing and slice workers.

### Nice to haves

1) I've tidied up the CLI output....I'm not sure if/who was using the "Hit X was outside the detector!" output, but it spammed and added thousands and thousands of lines to the CLI output. I can undo if it is legitimately useful, but for now, I've just condensed it into a "This many hits in view X were outside the TPC"

2) Using Isobel's recently added `EventContext`, I've somewhat populated the Run, SubRun and Event info in the main Pandora instance. Not sure if its automatically copied to the workers (or if we need that). We should probably also do a pass of the metrics to use this instead now, so the event counts are always valid (vs the counters that I think fall out of sync if you skip events).

 - One caveat here: Run + Subrun info isn't populated in any of the files I've looked at. For now, I've set it up such that we instead process out the number from the input file: `MiniProd4_xxxx_0000182_xxx.root` will get set to Run/Subrun 182, to aide linking it back to a specific file. Maybe we should also chat with the FD people and work out if a "filename" option would be useful too...

3) I've set all 3D + 2D hits that come from the same true 3D position, to have the same parent ID. That simplifies finding "2D Hit X and 3D Hit Y are the same". I should probably also write a helper to do that bit....

4) I've added the XML changes I've mentioned before, reducing the maximum tensor tool repeat count from 1000 to 100. **This could have a Physics impact!**. I need to triple check this over some files, but it does drastically reduce the running time, and from past experience repeats over 100 are usually stuck in a loop and broken anyways.

5) Finally...not quite complete but I've started to add the 3D gaps code. The 3D gaps should be fine, I just need to work out the right code for projecting them into 2D as well.

TODO List:

 - [ ] Check Physics Impact of changing XMLs.
 - [ ] Add 2D Gaps Code
 - [ ] Add Helper for matching 3D + 2D Hits
 - [ ] Check nobody is using the CLI output I removed

Probably some other bits, but this gets the ball rolling at least.