### PR TITLE
General Updates - Without Gap Code

### DIFF
--- a/include/MasterThreeDAlgorithm.h
+++ b/include/MasterThreeDAlgorithm.h
@@ -37,6 +37,22 @@ protected:
     pandora::StatusCode Run() override;
 
     /**
+     *  @brief  Copy mc particles in the named input list to the given pandora instance.
+     *
+     *  @param  pPandora the pandora instance to which to copy the mc particles
+     */
+    pandora::StatusCode CopyMCParticles(const pandora::Pandora *pPandora) const;
+
+
+    /**
+     * @brief  Run cosmic-ray reconstruction, then recreate the resulting pfos in the current pandora instance.
+     *
+     * @param  volumeIdToHitListMap the LArTPC Volume ID to Hit List Map
+     * @param  pfoToLArTPCMap To receive the mapping from pfos
+     */
+    pandora::StatusCode RunCosmicRayReconstructionThenRecreate(const VolumeIdToHitListMap &volumeIdToHitListMap, PfoToLArTPCMap &pfoToLArTPCMap) const;
+
+    /**
      *  @brief  Run cosmic-ray hit removal, freeing hits in ambiguous pfos for further processing
      *
      *  @param  ambiguousPfos the list of ambiguous cosmic-ray pfos

--- a/settings/PandoraSettings_Neutrino_ThreeD_DLVtx.xml
+++ b/settings/PandoraSettings_Neutrino_ThreeD_DLVtx.xml
@@ -139,6 +139,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -158,6 +159,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -169,6 +171,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>
@@ -204,6 +207,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <ShowerTools>
             <tool type = "LArClearShowers"/>
             <tool type = "LArSplitShowers"/>
@@ -217,6 +221,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -236,6 +241,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -247,6 +253,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>

--- a/settings/PandoraSettings_Neutrino_ThreeD_Merged.xml
+++ b/settings/PandoraSettings_Neutrino_ThreeD_Merged.xml
@@ -129,6 +129,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -148,6 +149,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -159,6 +161,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>
@@ -173,7 +176,7 @@
 <!--        <MaxShowerLengthCut>500.</MaxShowerLengthCut> -->
         <VertexDistanceRatioCut>500.</VertexDistanceRatioCut>
         <SlidingFitWindow>10</SlidingFitWindow>
-        <ShowerWidthRatioCut>2.0</ShowerWidthRatioCut> 
+        <ShowerWidthRatioCut>2.0</ShowerWidthRatioCut>
     </algorithm>
     <algorithm type = "LArListDeletion">
         <PfoListNames>ShowerParticles3D</PfoListNames>
@@ -194,6 +197,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <ShowerTools>
             <tool type = "LArClearShowers"/>
             <tool type = "LArSplitShowers"/>
@@ -207,6 +211,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -226,6 +231,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -237,6 +243,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>
@@ -306,7 +313,7 @@
         <DaughterListNames>ClustersU ClustersV ClustersW</DaughterListNames>
         <AddHitsAsIsolated>true</AddHitsAsIsolated>
     </algorithm>
-    
+
     <algorithm type = "LArBdtPfoCharacterisation">
         <TrackPfoListName>TrackParticles3D</TrackPfoListName>
         <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>

--- a/settings/PandoraSettings_Slicing_ThreeD.xml
+++ b/settings/PandoraSettings_Slicing_ThreeD.xml
@@ -85,6 +85,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -104,6 +105,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -115,6 +117,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>
@@ -150,6 +153,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <ShowerTools>
             <tool type = "LArClearShowers"/>
             <tool type = "LArSplitShowers"/>
@@ -167,6 +171,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -186,6 +191,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -197,6 +203,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>

--- a/settings/PandoraSettings_Slicing_ThreeD_Merged.xml
+++ b/settings/PandoraSettings_Slicing_ThreeD_Merged.xml
@@ -91,6 +91,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -110,6 +111,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -121,6 +123,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>
@@ -153,6 +156,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <ShowerTools>
             <tool type = "LArClearShowers"/>
             <tool type = "LArSplitShowers"/>
@@ -166,6 +170,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTracks"/>
             <tool type = "LArLongTracks"/>
@@ -185,6 +190,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearLongitudinalTracks"/>
             <tool type = "LArMatchedEndPoints"/>
@@ -196,6 +202,7 @@
         <InputClusterListNameV>ClustersV</InputClusterListNameV>
         <InputClusterListNameW>ClustersW</InputClusterListNameW>
         <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <NMaxTensorToolRepeats>100</NMaxTensorToolRepeats>
         <TrackTools>
             <tool type = "LArClearTrackFragments"/>
         </TrackTools>

--- a/src/CheatingRockMuonRemovalAlgorithm.cc
+++ b/src/CheatingRockMuonRemovalAlgorithm.cc
@@ -36,10 +36,14 @@ bool CheatingRockMuonRemovalAlgorithm::IsRockMuon(const Pandora &pandora, const 
 
 StatusCode CheatingRockMuonRemovalAlgorithm::Run()
 {
-
     // Load the input lists
-    const CaloHitList *pCaloHitList = NULL;
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pCaloHitList, m_inputCaloHitListName));
+    const CaloHitList *pCaloHitList(nullptr);
+
+    if (PandoraContentApi::GetList(*this, m_inputCaloHitListName, pCaloHitList) != STATUS_CODE_SUCCESS)
+    {
+        std::cout << "CheatingRockMuonRemovalAlgorithm: No calo hit list found with name: " << m_inputCaloHitListName << ", skipping!" << std::endl;
+        return STATUS_CODE_FAILURE;
+    }
 
     // Create the output lists
     CaloHitList pRockMuonCaloHitList;
@@ -48,12 +52,24 @@ StatusCode CheatingRockMuonRemovalAlgorithm::Run()
     // Process the hits
     for (const CaloHit *const pCaloHit : *pCaloHitList)
     {
-        const MCParticle *const pMCParticle = MCParticleHelper::GetMainMCParticle(pCaloHit);
-        if (this->IsRockMuon(this->GetPandora(), pMCParticle))
-            pRockMuonCaloHitList.push_back(pCaloHit);
-        else
-            pNeutrinoCaloHitList.push_back(pCaloHit);
+        try
+        {
+            const MCParticle *const pMCParticle = MCParticleHelper::GetMainMCParticle(pCaloHit);
+
+            if (this->IsRockMuon(this->GetPandora(), pMCParticle))
+                pRockMuonCaloHitList.push_back(pCaloHit);
+            else
+                pNeutrinoCaloHitList.push_back(pCaloHit);
+        }
+        catch (StatusCodeException &)
+        {
+            // INFO: There may be small number of hits with no associated MC... we don't want to break on them.
+            continue;
+        }
     }
+
+    if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
+        std::cout << "CheatingRockMuonRemovalAlgorithm: Rock muon hits: " << pRockMuonCaloHitList.size() << ", Neutrino hits: " << pNeutrinoCaloHitList.size() << std::endl;
 
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, pRockMuonCaloHitList, m_rockMuonCaloHitListName));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, pNeutrinoCaloHitList, m_neutrinoCaloHitListName));

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -27,6 +27,7 @@
 #include "larpandoracontent/LArPlugins/LArRotationalTransformationPlugin.h"
 
 #include "larpandoracontent/LArUtility/PfoMopUpBaseAlgorithm.h"
+#include <larpandoracontent/LArControlFlow/MasterAlgorithm.h>
 
 #ifdef LIBTORCH_DL
 #include "larpandoradlcontent/LArDLContent.h"
@@ -46,19 +47,14 @@ StatusCode MasterThreeDAlgorithm::Run()
     if (!m_workerInstancesInitialized)
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->InitializeWorkerInstances());
 
-    if (m_passMCParticlesToWorkerInstances)
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CopyMCParticles());
-
     PfoToFloatMap stitchedPfosToX0Map;
     VolumeIdToHitListMap volumeIdToHitListMap;
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetVolumeIdToHitListMap(volumeIdToHitListMap));
 
     if (m_shouldRunAllHitsCosmicReco)
     {
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RunCosmicRayReconstruction(volumeIdToHitListMap));
-
         PfoToLArTPCMap pfoToLArTPCMap;
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RecreateCosmicRayPfos(pfoToLArTPCMap));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RunCosmicRayReconstructionThenRecreate(volumeIdToHitListMap, pfoToLArTPCMap));
 
         if (m_shouldRunStitching)
             PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->StitchCosmicRayPfos(pfoToLArTPCMap, stitchedPfosToX0Map));
@@ -76,6 +72,9 @@ StatusCode MasterThreeDAlgorithm::Run()
 
     if (m_shouldRunNeutrinoRecoOption || m_shouldRunCosmicRecoOption)
     {
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CopyMCParticles(m_pSliceNuWorkerInstance));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CopyMCParticles(m_pSliceCRWorkerInstance));
+
         SliceHypotheses nuSliceHypotheses, crSliceHypotheses;
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RunSliceReconstruction(sliceVector, nuSliceHypotheses, crSliceHypotheses));
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->SelectBestSliceHypotheses(nuSliceHypotheses, crSliceHypotheses));
@@ -83,6 +82,23 @@ StatusCode MasterThreeDAlgorithm::Run()
 
     return STATUS_CODE_SUCCESS;
 }
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode MasterThreeDAlgorithm::CopyMCParticles(const Pandora *pPandora) const
+{
+    if (!m_passMCParticlesToWorkerInstances)
+        return STATUS_CODE_SUCCESS;
+
+    const MCParticleList *pMCParticleList(nullptr);
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_inputMCParticleListName, pMCParticleList));
+    LArMCParticleFactory mcParticleFactory;
+
+    for (const MCParticle *const pMCParticle : *pMCParticleList)
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->Copy(pPandora, pMCParticle, &mcParticleFactory));
+
+    return STATUS_CODE_SUCCESS;
+}
+
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode MasterThreeDAlgorithm::RunCosmicRayHitRemoval(const PfoList &ambiguousPfos) const
@@ -126,6 +142,44 @@ StatusCode MasterThreeDAlgorithm::RunCosmicRayHitRemoval(const PfoList &ambiguou
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+StatusCode MasterThreeDAlgorithm::RunCosmicRayReconstructionThenRecreate(const VolumeIdToHitListMap &volumeIdToHitListMap, PfoToLArTPCMap &pfoToLArTPCMap) const
+{
+    unsigned int workerCounter(0);
+
+    for (const Pandora *const pCRWorker : m_crWorkerInstances)
+    {
+        const LArTPC &larTPC(pCRWorker->GetGeometry()->GetLArTPC());
+        VolumeIdToHitListMap::const_iterator iter(volumeIdToHitListMap.find(larTPC.GetLArTPCVolumeId()));
+
+        if (volumeIdToHitListMap.end() == iter)
+            continue;
+
+        for (const CaloHit *const pCaloHit : iter->second.m_allHitList)
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->Copy(pCRWorker, pCaloHit));
+
+        if (m_printOverallRecoStatus)
+            std::cout << "Running cosmic-ray reconstruction worker instance " << ++workerCounter << " of " << m_crWorkerInstances.size() << std::endl;
+
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CopyMCParticles(pCRWorker));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::ProcessEvent(*pCRWorker));
+
+        const PfoList *pCRPfos(nullptr);
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::GetCurrentPfoList(*pCRWorker, pCRPfos));
+
+        PfoList newPfoList;
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, MasterAlgorithm::Recreate(*pCRPfos, newPfoList));
+
+        for (const Pfo *const pNewPfo : newPfoList)
+            pfoToLArTPCMap[pNewPfo] = &larTPC;
+
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::Reset(*pCRWorker));
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 StatusCode MasterThreeDAlgorithm::RunSlicing(const VolumeIdToHitListMap &volumeIdToHitListMap, SliceVector &sliceVector) const
 {
     std::cout << "There are " << volumeIdToHitListMap.size() << " volumes" << std::endl;
@@ -156,6 +210,7 @@ StatusCode MasterThreeDAlgorithm::RunSlicing(const VolumeIdToHitListMap &volumeI
             std::cout << "Running slicing worker instance" << std::endl;
 
         const PfoList *pSlicePfos(nullptr);
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CopyMCParticles(m_pSlicingWorkerInstance));
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::ProcessEvent(*m_pSlicingWorkerInstance));
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::GetCurrentPfoList(*m_pSlicingWorkerInstance, pSlicePfos));
 

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -486,6 +486,7 @@ StatusCode MasterThreeDAlgorithm::GetVolumeIdToHitListMap(VolumeIdToHitListMap &
 
     const CaloHitList *pCaloHitList(nullptr);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_inputHitListName, pCaloHitList));
+    std::map<HitType, std::pair<unsigned int, unsigned int>> hitTypeToStatusMap;
 
     for (const CaloHit *const pCaloHit : *pCaloHitList)
     {
@@ -504,11 +505,18 @@ StatusCode MasterThreeDAlgorithm::GetVolumeIdToHitListMap(VolumeIdToHitListMap &
                 (pCaloHit->GetPositionVector().GetX() <= (pLArTPC->GetCenterX() + 0.5f * pLArTPC->GetWidthX()))))
         {
             larTPCHitList.m_truncatedHitList.push_back(pCaloHit);
+            hitTypeToStatusMap[pCaloHit->GetHitType()].first++;
         }
         else
-            std::cout << "Hit of type " << pCaloHit->GetHitType() << " outside TPC " << volumeId << "? "
-                      << pCaloHit->GetPositionVector().GetX() << ", " << pLArTPC->GetCenterX() - 0.5f * pLArTPC->GetWidthX() << ", "
-                      << pLArTPC->GetCenterX() + 0.5f * pLArTPC->GetWidthX() << std::endl;
+            hitTypeToStatusMap[pCaloHit->GetHitType()].second++;
+    }
+
+    for (const auto &hitTypeToStatusMapEntry : hitTypeToStatusMap)
+    {
+        const HitType hitType(hitTypeToStatusMapEntry.first);
+        const unsigned int nInTimeHits(hitTypeToStatusMapEntry.second.first);
+        const unsigned int nOutOfTimeHits(hitTypeToStatusMapEntry.second.second);
+        std::cout << "Hit type " << hitType << ": " << nInTimeHits << " hits in TPC, " << nOutOfTimeHits << " hits outside of the TPC" << std::endl;
     }
 
     return STATUS_CODE_SUCCESS;

--- a/src/MasterThreeDAlgorithm.cc
+++ b/src/MasterThreeDAlgorithm.cc
@@ -40,8 +40,6 @@ namespace lar_content
 
 StatusCode MasterThreeDAlgorithm::Run()
 {
-    std::cout << "Should run slicing? " << m_shouldRunSlicing << std::endl;
-
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->Reset());
 
     if (!m_workerInstancesInitialized)
@@ -182,10 +180,8 @@ StatusCode MasterThreeDAlgorithm::RunCosmicRayReconstructionThenRecreate(const V
 
 StatusCode MasterThreeDAlgorithm::RunSlicing(const VolumeIdToHitListMap &volumeIdToHitListMap, SliceVector &sliceVector) const
 {
-    std::cout << "There are " << volumeIdToHitListMap.size() << " volumes" << std::endl;
     for (const VolumeIdToHitListMap::value_type &mapEntry : volumeIdToHitListMap)
     {
-        std::cout << "- Volume has " << mapEntry.second.m_allHitList.size() << " hits" << std::endl;
         for (const CaloHit *const pCaloHit : (m_shouldRemoveOutOfTimeHits ? mapEntry.second.m_truncatedHitList : mapEntry.second.m_allHitList))
         {
             if (!PandoraContentApi::IsAvailable(*this, pCaloHit))
@@ -511,12 +507,15 @@ StatusCode MasterThreeDAlgorithm::GetVolumeIdToHitListMap(VolumeIdToHitListMap &
             hitTypeToStatusMap[pCaloHit->GetHitType()].second++;
     }
 
-    for (const auto &hitTypeToStatusMapEntry : hitTypeToStatusMap)
+    if (m_printOverallRecoStatus)
     {
-        const HitType hitType(hitTypeToStatusMapEntry.first);
-        const unsigned int nInTimeHits(hitTypeToStatusMapEntry.second.first);
-        const unsigned int nOutOfTimeHits(hitTypeToStatusMapEntry.second.second);
-        std::cout << "Hit type " << hitType << ": " << nInTimeHits << " hits in TPC, " << nOutOfTimeHits << " hits outside of the TPC" << std::endl;
+        for (const auto &hitTypeToStatusMapEntry : hitTypeToStatusMap)
+        {
+            const HitType hitType(hitTypeToStatusMapEntry.first);
+            const unsigned int nInTimeHits(hitTypeToStatusMapEntry.second.first);
+            const unsigned int nOutOfTimeHits(hitTypeToStatusMapEntry.second.second);
+            std::cout << "Hit type " << hitType << ": " << nInTimeHits << " hits in TPC, " << nOutOfTimeHits << " hits outside of the TPC" << std::endl;
+        }
     }
 
     return STATUS_CODE_SUCCESS;

--- a/src/PfoThreeDHitAssignmentAlgorithm.cc
+++ b/src/PfoThreeDHitAssignmentAlgorithm.cc
@@ -274,13 +274,11 @@ void PfoThreeDHitAssignmentAlgorithm::AddHitsToPfo(const ParticleFlowObject *pPf
 
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Cluster>(*this, listName));
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::AddToPfo(*this, pPfo, pCluster3D));
-        std::cout << "Pfo " << pPfo << ": created cluster " << pCluster3D << " with " << hits.size() << " hits" << std::endl;
     }
     else if (1 == nClusters)
     {
         const Cluster *const pCluster3D = *(clusters3D.begin());
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::AddToCluster(*this, pCluster3D, &hits));
-        std::cout << "Pfo " << pPfo << ": added " << hits.size() << " hits to existing cluster " << pCluster3D << std::endl;
     }
     else
         throw StatusCodeException(STATUS_CODE_FAILURE);

--- a/src/PfoThreeDHitAssignmentAlgorithm.cc
+++ b/src/PfoThreeDHitAssignmentAlgorithm.cc
@@ -35,8 +35,6 @@ pandora::StatusCode PfoThreeDHitAssignmentAlgorithm::Run()
     if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
-    std::cout << "Running 3D hit assignment" << std::endl;
-
     const CaloHitList *pCaloHits3D{nullptr};
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_inputCaloHitList3DName, pCaloHits3D));
 

--- a/src/PreProcessingThreeDAlgorithm.cc
+++ b/src/PreProcessingThreeDAlgorithm.cc
@@ -80,7 +80,12 @@ StatusCode PreProcessingThreeDAlgorithm::Run()
 void PreProcessingThreeDAlgorithm::ProcessCaloHits()
 {
     const CaloHitList *pCaloHitList(nullptr);
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_inputCaloHitListName, pCaloHitList));
+
+    if (PandoraContentApi::GetList(*this, m_inputCaloHitListName, pCaloHitList) != STATUS_CODE_SUCCESS)
+    {
+        std::cout << "PreProcessingThreeDAlgorithm: No calo hit list found with name: " << m_inputCaloHitListName << ", skipping!" << std::endl;
+        return;
+    }
 
     if (pCaloHitList->empty())
         return;
@@ -203,6 +208,7 @@ void PreProcessingThreeDAlgorithm::GetFilteredCaloHitList(const CaloHitList &inp
     kdTree.build(hitKDNode2DList, hitsBoundingRegion2D);
 
     // Remove hits that are in the same physical location!
+    int removedHitsCounter(0);
     for (const CaloHit *const pCaloHit1 : inputList)
     {
         bool isUnique(true);
@@ -235,15 +241,13 @@ void PreProcessingThreeDAlgorithm::GetFilteredCaloHitList(const CaloHitList &inp
         }
 
         if (isUnique)
-        {
             outputList.push_back(pCaloHit1);
-        }
         else
-        {
-            if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
-                std::cout << "PreProcessingThreeDAlgorithm: found two hits in same location, will remove lowest pulse height" << std::endl;
-        }
+            removedHitsCounter++;
     }
+
+    if (removedHitsCounter > 0 && PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
+        std::cout << "PreProcessingThreeDAlgorithm: removed " << removedHitsCounter << " hits that were in the same location as another hit" << std::endl;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/PreProcessingThreeDAlgorithm.cc
+++ b/src/PreProcessingThreeDAlgorithm.cc
@@ -150,9 +150,6 @@ void PreProcessingThreeDAlgorithm::ProcessCaloHits()
     filteredInputList.insert(filteredInputList.end(), filteredCaloHitListV.begin(), filteredCaloHitListV.end());
     filteredInputList.insert(filteredInputList.end(), filteredCaloHitListW.begin(), filteredCaloHitListW.end());
 
-    std::cout << "Hit list sizes: " << filteredCaloHitListU.size() << ", " << filteredCaloHitListV.size() << ", "
-              << filteredCaloHitListW.size() << ", " << selectedCaloHitList3D.size() << std::endl;
-
     if (!filteredInputList.empty() && !m_filteredCaloHitListName.empty())
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, filteredInputList, m_filteredCaloHitListName));
 

--- a/src/SimpleClusterCreationThreeDAlgorithm.cc
+++ b/src/SimpleClusterCreationThreeDAlgorithm.cc
@@ -114,7 +114,9 @@ StatusCode SimpleClusterCreationThreeDAlgorithm::CreateClusters(const CaloHitLis
 
     std::vector<PandoraContentApi::Cluster::Parameters> clusters3D;
 
-    std::cout << "Making clusters from " << caloHitVector.size() << " 3D hits" << std::endl;
+    if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
+        std::cout << "SimpleClusterCreationThreeDAlgorithm: Making clusters from " << caloHitVector.size() << " 3D hits" << std::endl;
+
     for (const CaloHit *const pSeedCaloHit : caloHitVector)
     {
         if (vetoList.count(pSeedCaloHit))

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -14,6 +14,7 @@
 #include "TGeoMatrix.h"
 #include "TGeoShape.h"
 #include "TGeoVolume.h"
+#include <regex>
 
 #ifdef USE_EDEPSIM
 #include "TG4PrimaryVertex.h"
@@ -361,6 +362,29 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
             LArSPMC *larspmc = dynamic_cast<LArSPMC *>(larsp.get());
             CreateSPMCParticles(*larspmc, pPrimaryPandora, parameters);
         }
+
+        // And event level information...
+        int run{0};
+        int subrun{0};
+        const int event{larsp->m_event};
+
+        // INFO: Currently, the run + subrun fields are seemingly not set in the
+        // input ROOT files, so we can instead parse it from the input file
+        // name, if possible.
+        //
+        // This should pull out 12 from
+        // MiniProdN5p1_NDComplex_FHC.flow.full.sanddrift.0000012.FLOW.hdf5_hits.root
+        std::regex fileNameRegex(".*\\.(\\d+)\\.FLOW.*");
+        std::smatch matches;
+
+        if (std::regex_match(parameters.m_inputFileName, matches, fileNameRegex) && matches.size() > 1)
+        {
+            run = std::stoi(matches[1].str());
+            subrun = run;
+        }
+
+        std::cout << "Event info: run " << run << ", subrun " << subrun << ", event " << event << std::endl;
+        PandoraApi::SetEventInformation(*pPrimaryPandora, run, subrun, event);
 
         int hitCounter(0);
 

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -428,7 +428,7 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
             caloHitParameters.m_hitRegion = pandora::SINGLE_REGION;
             caloHitParameters.m_layer = 0;
             caloHitParameters.m_isInOuterSamplingLayer = false;
-            caloHitParameters.m_pParentAddress = (void *)(static_cast<uintptr_t>(++hitCounter));
+            caloHitParameters.m_pParentAddress = (void *)(static_cast<uintptr_t>(hitCounter));
             caloHitParameters.m_larTPCVolumeId = tpcID < 0 ? 0 : tpcID;
             caloHitParameters.m_daughterVolumeId = 0;
 
@@ -473,7 +473,7 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
                 // U view
                 lar_content::LArCaloHitParameters caloHitPars_UView(caloHitParameters);
                 caloHitPars_UView.m_hitType = pandora::TPC_VIEW_U;
-                caloHitPars_UView.m_pParentAddress = (void *)(intptr_t(++hitCounter));
+                caloHitPars_UView.m_pParentAddress = (void *)(intptr_t(hitCounter));
                 const float upos_cm(pPrimaryPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoU(y0_cm, z0_cm));
                 caloHitPars_UView.m_positionVector = pandora::CartesianVector(x0_cm, 0.f, upos_cm);
 
@@ -486,7 +486,7 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
                 // V view
                 lar_content::LArCaloHitParameters caloHitPars_VView(caloHitParameters);
                 caloHitPars_VView.m_hitType = pandora::TPC_VIEW_V;
-                caloHitPars_VView.m_pParentAddress = (void *)(intptr_t(++hitCounter));
+                caloHitPars_VView.m_pParentAddress = (void *)(intptr_t(hitCounter));
                 const float vpos_cm(pPrimaryPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoV(y0_cm, z0_cm));
                 caloHitPars_VView.m_positionVector = pandora::CartesianVector(x0_cm, 0.f, vpos_cm);
                 PANDORA_THROW_RESULT_IF(
@@ -497,7 +497,7 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
                 // W view
                 lar_content::LArCaloHitParameters caloHitPars_WView(caloHitParameters);
                 caloHitPars_WView.m_hitType = pandora::TPC_VIEW_W;
-                caloHitPars_WView.m_pParentAddress = (void *)(intptr_t(++hitCounter));
+                caloHitPars_WView.m_pParentAddress = (void *)(intptr_t(hitCounter));
                 const float wpos_cm(pPrimaryPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoW(y0_cm, z0_cm));
                 caloHitPars_WView.m_positionVector = pandora::CartesianVector(x0_cm, 0.f, wpos_cm);
 
@@ -507,6 +507,9 @@ void ProcessSPEvents(const Parameters &parameters, const Pandora *const pPrimary
                     PandoraApi::SetCaloHitToMCParticleRelationship(
                         *pPrimaryPandora, (void *)((intptr_t)hitCounter), (void *)((intptr_t)trackID), energyFrac);
             }
+
+            // Increment hit counter for unique Hit IDs
+            ++hitCounter;
 
         } // end space point loop
 

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -253,9 +253,6 @@ void MakePandoraTPC(const pandora::Pandora *const pPrimaryPandora, const Paramet
         geoparameters.m_isDriftInPositiveX = tpcNumber % 2;
 
         geom.AddTPC(centreX - dx, centreX + dx, centreY - dy, centreY + dy, centreZ - dz, centreZ + dz, tpcNumber);
-
-        std::cout << "Creating TPC: " << centreX - dx << ", " << centreX + dx << ", " << centreY - dy << ", " << centreY + dy << ", "
-                  << centreZ - dz << ", " << centreZ + dz << std::endl;
     }
     catch (const pandora::StatusCodeException &)
     {


### PR DESCRIPTION
Opening this as a draft, because there is some TODO notes, and bits to check...

This adds some of the infrastructure changes I've made recently, decoupled from the DL Slicing work.

### Worker Revamp

Currently, the top level workflow in the master algorithm is this:

 - Copy all MC to all workers
 - Run every Cosmic Worker
 - Process every Cosmic Worker
 - Run Slicing
 - Run Slice Reco

That is fairly wasteful though. All ~100-200,000 MC hits and what not are copied to 70 CR workers, and then just left there, ballooning the RAM usage.

I've swapped it to:

 - Copy MC to CR Worker 1, Run CR Worker 1, Process CR Worker 1, Reset CR Worker 1.
 - Repeat for all workers
 - Copy MC to Slicing Worker, Run Slicing
 - Copy MC to Slice Reco Workers, Run Slice Reco Workers

That gets things in much better control, without requiring larger changes. We still copy over all 100-200k hits to each worker when they will only need 1/70th of it...but that is a larger more involved change. Same for the slicing and slice workers.

### Nice to haves

1) I've tidied up the CLI output....I'm not sure if/who was using the "Hit X was outside the detector!" output, but it spammed and added thousands and thousands of lines to the CLI output. I can undo if it is legitimately useful, but for now, I've just condensed it into a "This many hits in view X were outside the TPC"

2) Using Isobel's recently added `EventContext`, I've somewhat populated the Run, SubRun and Event info in the main Pandora instance. Not sure if its automatically copied to the workers (or if we need that). We should probably also do a pass of the metrics to use this instead now, so the event counts are always valid (vs the counters that I think fall out of sync if you skip events).

 - One caveat here: Run + Subrun info isn't populated in any of the files I've looked at. For now, I've set it up such that we instead process out the number from the input file: `MiniProd4_xxxx_0000182_xxx.root` will get set to Run/Subrun 182, to aide linking it back to a specific file. Maybe we should also chat with the FD people and work out if a "filename" option would be useful too...

3) I've set all 3D + 2D hits that come from the same true 3D position, to have the same parent ID. That simplifies finding "2D Hit X and 3D Hit Y are the same". I should probably also write a helper to do that bit....

4) I've added the XML changes I've mentioned before, reducing the maximum tensor tool repeat count from 1000 to 100. **This could have a Physics impact!**. I need to triple check this over some files, but it does drastically reduce the running time, and from past experience repeats over 100 are usually stuck in a loop and broken anyways.

TODO List:

 - [ ] Check Physics Impact of changing XMLs.
 - [ ] Add Helper for matching 3D + 2D Hits
 - [ ] Check nobody is using the CLI output I removed

Probably some other bits, but this gets the ball rolling at least.