### PR TITLE
Hierarchy Ana Fix: Get best match not first.

### DIFF
--- a/src/HierarchyAnalysisAlgorithm.cc
+++ b/src/HierarchyAnalysisAlgorithm.cc
@@ -573,23 +573,17 @@ const HierarchyAnalysisAlgorithm::RecoMCMatch HierarchyAnalysisAlgorithm::GetRec
 {
     int nSharedHits{0};
     float completeness{0.f}, purity{0.f};
-    bool foundMatch{false};
 
     const MCParticle *pRootNu{nullptr}, *pLeadingMC{nullptr};
 
     // Loop over the root (neutrino) MC particles
     for (const MCParticle *const pMCRoot : rootMCParticles)
     {
-        if (foundMatch)
-            break;
-
         // Loop over the possible matches
         const LArHierarchyHelper::MCMatchesVector &matches{matchInfo.GetMatches(pMCRoot)};
 
         for (const LArHierarchyHelper::MCMatches &match : matches)
         {
-            if (foundMatch)
-                break;
             // MC node
             const LArHierarchyHelper::MCHierarchy::Node *pMCNode{match.GetMC()};
 
@@ -599,13 +593,6 @@ const HierarchyAnalysisAlgorithm::RecoMCMatch HierarchyAnalysisAlgorithm::GetRec
             // See if the current recoNode is in the reco matches vector
             if (std::find(nodeVector.begin(), nodeVector.end(), pRecoNode) != nodeVector.end())
             {
-                foundMatch = true;
-
-                // Parent neutrino
-                pRootNu = pMCRoot;
-                // Best matched leading MC particle
-                pLeadingMC = pMCNode->GetLeadingMCParticle();
-
                 // The MC matching uses nodes which can have more than 1 folded particle/PFO.
                 // The PFO passed to this function will be part of the matched reco node
                 // once the code reaches here, but this reco node can have more than 1 PFO via folding.
@@ -640,12 +627,16 @@ const HierarchyAnalysisAlgorithm::RecoMCMatch HierarchyAnalysisAlgorithm::GetRec
                 CaloHitVector intersection;
                 std::set_intersection(mcHits.begin(), mcHits.end(), selectedPfoHits.begin(), selectedPfoHits.end(), std::back_inserter(intersection));
 
-                nSharedHits = intersection.size();
-                completeness = (mcHits.size() > 0) ? nSharedHits / static_cast<float>(mcHits.size()) : 0.0;
-                purity = (selectedPfoHits.size() > 0) ? nSharedHits / static_cast<float>(selectedPfoHits.size()) : 0.0;
+                const int currentSharedHits = intersection.size();
 
-                break;
-
+                if (currentSharedHits > nSharedHits)
+                {
+                    nSharedHits = currentSharedHits;
+                    completeness = (mcHits.size() > 0) ? nSharedHits / static_cast<float>(mcHits.size()) : 0.0;
+                    purity = (selectedPfoHits.size() > 0) ? nSharedHits / static_cast<float>(selectedPfoHits.size()) : 0.0;
+                    pRootNu = pMCRoot;
+                    pLeadingMC = pMCNode->GetLeadingMCParticle();
+                }
             } // Find recoNode
         } // Match loop
     } // Root MC particles


### PR DESCRIPTION
Essentially, these loops would stop at the first match, which due to the MC sorting being just by its momentum, meant the "best MC match" could be a teeny few hit overlap, but that overlap was with an MC particle with more momentum, meaning it was picked.

For example:

```
[DEBUG] -> First Match at index 66 / 138 | UID: 1541000013 | Mom: 4.30564 | Hits: 3
[DEBUG] -> New Best Match at index 66 / 138 | UID: 1541000013 | Mom: 4.30564 | Hits: 3
[DEBUG] -> New Best Match at index 109 / 138 | UID: 1541000010 | Mom: 2.38851 | Hits: 5384

[DEBUG GetRecoMCMatch] Summary for RecoNode:
    First Match: UID 1541000013 with 3 hits, completeness 0.0291262, purity 0.75
    Best Match: UID 1541000010 with 5384 hits, completeness 0.998887, purity 0.999443
```

In this case, we would have picked a 4.3 GeV match with only 3 overlapping hits with our PFO, over a 2.3 GeV match that had 5384 overlapping hits (with the overlap being on the projected 2D hits here).

Visually, its the difference between these two images: 

Before, we compare the PFO vs this random other vertex way below and with no hits around it...

<img width="1024" height="243" alt="image" src="https://github.com/user-attachments/assets/25f56a4a-de3b-42ba-a81b-28e44684af3b" />

Post fix, we now compare to the actual seemingly representative MC particle:

<img width="2314" height="540" alt="image" src="https://github.com/user-attachments/assets/deb3dbb1-954d-4e3b-81f3-3aef1f86c037" />

Now, we pick the "best" match by evaluating every option, and picking the MC that has the largest overlap: I.e. it shares the most hits with the PFP. This aligns much more closely with expectation, and all the rest of the code.
