### PR TITLE
Feature/save pfo parent

### DIFF
--- a/include/LArRecoNDFormat.h
+++ b/include/LArRecoNDFormat.h
@@ -63,6 +63,7 @@ public:
     Int_t m_trigger;
     std::vector<int> *m_sliceID = nullptr;
     std::vector<int> *m_clusterID = nullptr;
+    std::vector<int> *m_clusterParentID = nullptr;
     std::vector<float> *m_nuVtxX = nullptr;
     std::vector<float> *m_nuVtxY = nullptr;
     std::vector<float> *m_nuVtxZ = nullptr;
@@ -136,6 +137,7 @@ public:
     TBranch *m_b_trigger = nullptr;
     TBranch *m_b_sliceID = nullptr;
     TBranch *m_b_clusterID = nullptr;
+    TBranch *m_b_clusterParentID = nullptr;
     TBranch *m_b_nuVtxX = nullptr;
     TBranch *m_b_nuVtxY = nullptr;
     TBranch *m_b_nuVtxZ = nullptr;
@@ -262,6 +264,7 @@ void LArRecoNDFormat::Init(TTree *tree)
     m_fChain->SetBranchAddress("triggers", &m_trigger, &m_b_trigger);
     m_fChain->SetBranchAddress("sliceId", &m_sliceID, &m_b_sliceID);
     m_fChain->SetBranchAddress("clusterId", &m_clusterID, &m_b_clusterID);
+    m_fChain->SetBranchAddress("clusterParentId", &m_clusterParentID, &m_b_clusterParentID);
     m_fChain->SetBranchAddress("nuVtxX", &m_nuVtxX, &m_b_nuVtxX);
     m_fChain->SetBranchAddress("nuVtxY", &m_nuVtxY, &m_b_nuVtxY);
     m_fChain->SetBranchAddress("nuVtxZ", &m_nuVtxZ, &m_b_nuVtxZ);

--- a/include/LArRecoNDFormat.h
+++ b/include/LArRecoNDFormat.h
@@ -64,6 +64,7 @@ public:
     std::vector<int> *m_sliceID = nullptr;
     std::vector<int> *m_clusterID = nullptr;
     std::vector<int> *m_clusterParentID = nullptr;
+    std::vector<int> *m_nClusterParents = nullptr;
     std::vector<float> *m_nuVtxX = nullptr;
     std::vector<float> *m_nuVtxY = nullptr;
     std::vector<float> *m_nuVtxZ = nullptr;
@@ -138,6 +139,7 @@ public:
     TBranch *m_b_sliceID = nullptr;
     TBranch *m_b_clusterID = nullptr;
     TBranch *m_b_clusterParentID = nullptr;
+    TBranch *m_b_nClusterParents = nullptr;
     TBranch *m_b_nuVtxX = nullptr;
     TBranch *m_b_nuVtxY = nullptr;
     TBranch *m_b_nuVtxZ = nullptr;
@@ -265,6 +267,7 @@ void LArRecoNDFormat::Init(TTree *tree)
     m_fChain->SetBranchAddress("sliceId", &m_sliceID, &m_b_sliceID);
     m_fChain->SetBranchAddress("clusterId", &m_clusterID, &m_b_clusterID);
     m_fChain->SetBranchAddress("clusterParentId", &m_clusterParentID, &m_b_clusterParentID);
+    m_fChain->SetBranchAddress("nClusterParents", &m_nClusterParents, &m_b_nClusterParents);
     m_fChain->SetBranchAddress("nuVtxX", &m_nuVtxX, &m_b_nuVtxX);
     m_fChain->SetBranchAddress("nuVtxY", &m_nuVtxY, &m_b_nuVtxY);
     m_fChain->SetBranchAddress("nuVtxZ", &m_nuVtxZ, &m_b_nuVtxZ);

--- a/include/PandoraOuterface.h
+++ b/include/PandoraOuterface.h
@@ -318,6 +318,7 @@ private:
     std::vector<int> m_out_sliceID;
     std::vector<int> m_out_clusterID;
     std::vector<int> m_out_clusterParentID;
+    std::vector<int> m_out_nClusterParents;
     std::vector<float> m_out_nuVtxX;
     std::vector<float> m_out_nuVtxY;
     std::vector<float> m_out_nuVtxZ;
@@ -491,6 +492,7 @@ NDRecoOutputData::NDRecoOutputData(const std::string filename)
     m_treeOut->Branch("sliceId", &m_out_sliceID);
     m_treeOut->Branch("clusterId", &m_out_clusterID);
     m_treeOut->Branch("clusterParentId", &m_out_clusterParentID);
+    m_treeOut->Branch("nClusterParents", &m_out_nClusterParents);
     m_treeOut->Branch("nuVtxX", &m_out_nuVtxX);
     m_treeOut->Branch("nuVtxY", &m_out_nuVtxY);
     m_treeOut->Branch("nuVtxZ", &m_out_nuVtxZ);
@@ -627,6 +629,7 @@ void NDRecoOutputData::ClearData()
     m_out_sliceID.clear();
     m_out_clusterID.clear();
     m_out_clusterParentID.clear();
+    m_out_nClusterParents.clear();
     m_out_nuVtxX.clear();
     m_out_nuVtxY.clear();
     m_out_nuVtxZ.clear();
@@ -809,6 +812,7 @@ void NDRecoOutputData::FillBasicBranches(const std::unique_ptr<LArRecoNDFormat> 
     m_out_sliceID.insert(m_out_sliceID.end(), inputSpill->m_sliceID->begin(), inputSpill->m_sliceID->end());
     m_out_clusterID.insert(m_out_clusterID.end(), inputSpill->m_clusterID->begin(), inputSpill->m_clusterID->end());
     m_out_clusterParentID.insert(m_out_clusterParentID.end(), inputSpill->m_clusterParentID->begin(), inputSpill->m_clusterParentID->end());
+    m_out_nClusterParents.insert(m_out_nClusterParents.end(), inputSpill->m_nClusterParents->begin(), inputSpill->m_nClusterParents->end());
     m_out_nuVtxX.insert(m_out_nuVtxX.end(), inputSpill->m_nuVtxX->begin(), inputSpill->m_nuVtxX->end());
     m_out_nuVtxY.insert(m_out_nuVtxY.end(), inputSpill->m_nuVtxY->begin(), inputSpill->m_nuVtxY->end());
     m_out_nuVtxZ.insert(m_out_nuVtxZ.end(), inputSpill->m_nuVtxZ->begin(), inputSpill->m_nuVtxZ->end());

--- a/include/PandoraOuterface.h
+++ b/include/PandoraOuterface.h
@@ -317,6 +317,7 @@ private:
     Int_t m_out_trigger;
     std::vector<int> m_out_sliceID;
     std::vector<int> m_out_clusterID;
+    std::vector<int> m_out_clusterParentID;
     std::vector<float> m_out_nuVtxX;
     std::vector<float> m_out_nuVtxY;
     std::vector<float> m_out_nuVtxZ;
@@ -489,6 +490,7 @@ NDRecoOutputData::NDRecoOutputData(const std::string filename)
     m_treeOut->Branch("triggers", &m_out_trigger);
     m_treeOut->Branch("sliceId", &m_out_sliceID);
     m_treeOut->Branch("clusterId", &m_out_clusterID);
+    m_treeOut->Branch("clusterParentId", &m_out_clusterParentID);
     m_treeOut->Branch("nuVtxX", &m_out_nuVtxX);
     m_treeOut->Branch("nuVtxY", &m_out_nuVtxY);
     m_treeOut->Branch("nuVtxZ", &m_out_nuVtxZ);
@@ -624,6 +626,7 @@ void NDRecoOutputData::ClearData()
     m_out_trigger = 0;
     m_out_sliceID.clear();
     m_out_clusterID.clear();
+    m_out_clusterParentID.clear();
     m_out_nuVtxX.clear();
     m_out_nuVtxY.clear();
     m_out_nuVtxZ.clear();
@@ -805,6 +808,7 @@ void NDRecoOutputData::FillBasicBranches(const std::unique_ptr<LArRecoNDFormat> 
     m_out_trigger = inputSpill->m_trigger;
     m_out_sliceID.insert(m_out_sliceID.end(), inputSpill->m_sliceID->begin(), inputSpill->m_sliceID->end());
     m_out_clusterID.insert(m_out_clusterID.end(), inputSpill->m_clusterID->begin(), inputSpill->m_clusterID->end());
+    m_out_clusterParentID.insert(m_out_clusterParentID.end(), inputSpill->m_clusterParentID->begin(), inputSpill->m_clusterParentID->end());
     m_out_nuVtxX.insert(m_out_nuVtxX.end(), inputSpill->m_nuVtxX->begin(), inputSpill->m_nuVtxX->end());
     m_out_nuVtxY.insert(m_out_nuVtxY.end(), inputSpill->m_nuVtxY->begin(), inputSpill->m_nuVtxY->end());
     m_out_nuVtxZ.insert(m_out_nuVtxZ.end(), inputSpill->m_nuVtxZ->begin(), inputSpill->m_nuVtxZ->end());

--- a/src/HierarchyAnalysisAlgorithm.cc
+++ b/src/HierarchyAnalysisAlgorithm.cc
@@ -273,13 +273,6 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
                 // Increment clusterId
                 clusterId++;
 
-                // Save ID of cluster parent. If parent list is empty, set to -1
-                //const pandora::PfoList &parentPfoList = pPfo->GetParentPfoList();
-                //if (!parentPfoList.empty())
-                //{
-                //    const pandora::ParticleFlowObject *const pParentPfo = parentPfoList.front();
-                //}
-
                 // Find first and last cluster hit points
                 CartesianVector first(max, max, max), last(max, max, max);
                 LArClusterHelper::GetExtremalCoordinates(pCluster3D, first, last);
@@ -484,7 +477,7 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
         } // Reco nodes
     } // Root PFOs
 
-
+    //Save parent pfo Ids
     for (const ParticleFlowObject *const pPfo : clusterPfoVect)
     {
         int clusterParentId{-1};

--- a/src/HierarchyAnalysisAlgorithm.cc
+++ b/src/HierarchyAnalysisAlgorithm.cc
@@ -183,7 +183,7 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
     // For storing various reconstructed PFO quantities in the given event
     int sliceId{-1};
     // Slice & cluster IDs, and number of hits
-    IntVector sliceIdVect, clusterIdVect, n3DHitsVect, nUHitsVect, nVHitsVect, nWHitsVect;
+    IntVector sliceIdVect, clusterIdVect, clusterParentIdVect, n3DHitsVect, nUHitsVect, nVHitsVect, nWHitsVect;
     // Cluster isShower, isRecoPrimary & reco PDG hypothesis, as well as the track score
     IntVector isShowerVect, isRecoPrimaryVect, recoPDGVect;
     FloatVector trackScoreVect;
@@ -207,6 +207,11 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
     std::vector<long> mcNuIdVect, mcIdVect, mcLocalIdVect, mcParentIdVect;
     //MC pfo parent info
     IntVector mcParentPDGVect;
+
+    // Map to store pfo <-> clusterId relations, used to find parentId
+    std::map<const ParticleFlowObject *, int> pfoToClusterIdMap;
+    // Vector of parent pfos for each pfo
+    std::vector<const ParticleFlowObject *> clusterPfoVect;
 
     // Hit info for each reconstructed PFO. Since we can't store vectors of vectors, the size of
     // these vectors = n3DHits*nPFOs, whereas all of the above vectors have size = nPFOs.
@@ -241,7 +246,7 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
         recoHierarchy.GetFlattenedNodes(pRoot, recoNodes);
 
         // Cluster id for the given slice
-        int clusterId{-1};
+        int clusterId{-1}; 
 
         // Loop over the reco nodes
         for (const LArHierarchyHelper::RecoHierarchy::Node *pRecoNode : recoNodes)
@@ -267,6 +272,13 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
 
                 // Increment clusterId
                 clusterId++;
+
+                // Save ID of cluster parent. If parent list is empty, set to -1
+                //const pandora::PfoList &parentPfoList = pPfo->GetParentPfoList();
+                //if (!parentPfoList.empty())
+                //{
+                //    const pandora::ParticleFlowObject *const pParentPfo = parentPfoList.front();
+                //}
 
                 // Find first and last cluster hit points
                 CartesianVector first(max, max, max), last(max, max, max);
@@ -319,6 +331,9 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
 
                 // Cluster Id
                 clusterIdVect.emplace_back(clusterId);
+                // Add this PFO and its clusterId to map
+                pfoToClusterIdMap[pPfo] = clusterId;
+                clusterPfoVect.emplace_back(pPfo);
 
                 // Number of hits in the cluster (by views)
                 n3DHitsVect.emplace_back(n3DHits);
@@ -469,6 +484,23 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
         } // Reco nodes
     } // Root PFOs
 
+
+    for (const ParticleFlowObject *const pPfo : clusterPfoVect)
+    {
+        int clusterParentId{-1};
+        const PfoList &parentPfoList = pPfo->GetParentPfoList();
+
+        if (!parentPfoList.empty())
+        {
+            const ParticleFlowObject *const pParentPfo = parentPfoList.front();
+            const auto parentIter = pfoToClusterIdMap.find(pParentPfo);
+            if (parentIter != pfoToClusterIdMap.end())
+                clusterParentId = parentIter->second;
+        }
+
+        clusterParentIdVect.emplace_back(clusterParentId);
+    }
+
     // Fill ROOT ntuple
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "event", m_event));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "run", m_run));
@@ -483,6 +515,7 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "nuVtxY", &nuVtxYVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "nuVtxZ", &nuVtxZVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "clusterId", &clusterIdVect));
+    PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "clusterParentId", &clusterParentIdVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "n3DHits", &n3DHitsVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "nUHits", &nUHitsVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "nVHits", &nVHitsVect));

--- a/src/HierarchyAnalysisAlgorithm.cc
+++ b/src/HierarchyAnalysisAlgorithm.cc
@@ -183,7 +183,7 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
     // For storing various reconstructed PFO quantities in the given event
     int sliceId{-1};
     // Slice & cluster IDs, and number of hits
-    IntVector sliceIdVect, clusterIdVect, clusterParentIdVect, n3DHitsVect, nUHitsVect, nVHitsVect, nWHitsVect;
+    IntVector sliceIdVect, clusterIdVect, nClusterParentsVect , clusterParentIdVect, n3DHitsVect, nUHitsVect, nVHitsVect, nWHitsVect;
     // Cluster isShower, isRecoPrimary & reco PDG hypothesis, as well as the track score
     IntVector isShowerVect, isRecoPrimaryVect, recoPDGVect;
     FloatVector trackScoreVect;
@@ -480,8 +480,9 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
     //Save parent pfo Ids
     for (const ParticleFlowObject *const pPfo : clusterPfoVect)
     {
-        int clusterParentId{-1};
+        int clusterParentId{-1}, nClusterParents{-1};
         const PfoList &parentPfoList = pPfo->GetParentPfoList();
+        nClusterParents = parentPfoList.size();
 
         if (!parentPfoList.empty())
         {
@@ -492,6 +493,7 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
         }
 
         clusterParentIdVect.emplace_back(clusterParentId);
+        nClusterParentsVect.emplace_back(nClusterParents);
     }
 
     // Fill ROOT ntuple
@@ -509,6 +511,7 @@ void HierarchyAnalysisAlgorithm::EventAnalysisOutput(const LArHierarchyHelper::M
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "nuVtxZ", &nuVtxZVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "clusterId", &clusterIdVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "clusterParentId", &clusterParentIdVect));
+    PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "nClusterParents", &nClusterParentsVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "n3DHits", &n3DHitsVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "nUHits", &nUHitsVect));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_analysisTreeName.c_str(), "nVHits", &nVHitsVect));


### PR DESCRIPTION
This PR adds, for every pfo, a parentID to the output of HierarchyAnalysis. This is set as the clusterId of the front Pfo in the pro's parent pfo list. This variable is also propagated through PandoraOuterface.