### PR TITLE
Feature/CollapsetoPrimaries (WIP)

### DIFF
--- a/settings/PandoraSettings_LArRecoND_ThreeD.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD.xml
@@ -1,6 +1,6 @@
 <pandora>
     <!-- GLOBAL SETTINGS -->
-    <IsMonitoringEnabled>false</IsMonitoringEnabled>
+    <IsMonitoringEnabled>true</IsMonitoringEnabled>
     <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
     <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
 

--- a/settings/PandoraSettings_LArRecoND_ThreeD.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD.xml
@@ -1,6 +1,6 @@
 <pandora>
     <!-- GLOBAL SETTINGS -->
-    <IsMonitoringEnabled>true</IsMonitoringEnabled>
+    <IsMonitoringEnabled>false</IsMonitoringEnabled>
     <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
     <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
 
@@ -23,7 +23,7 @@
 
     <algorithm type = "LArMasterThreeD">
         <CRSettingsFile>PandoraSettings_Cosmic_Standard.xml</CRSettingsFile>
-        <NuSettingsFile>PandoraSettings_Neutrino_ThreeD_Cheated.xml</NuSettingsFile>
+        <NuSettingsFile>PandoraSettings_Neutrino_ThreeD.xml</NuSettingsFile>
         <SlicingSettingsFile>PandoraSettings_Slicing_ThreeD.xml</SlicingSettingsFile>
         <StitchingTools>
             <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>true</ThreeDStitchingMode></tool>
@@ -36,8 +36,6 @@
             <tool type = "LArSimpleNeutrinoId"/>
         </SliceIdTools>
         <InputHitListName>Input</InputHitListName>
-        <InputMCParticleListName>Input</InputMCParticleListName>
-        <PassMCParticlesToWorkerInstances>true</PassMCParticlesToWorkerInstances>
         <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>
         <RecreatedClusterListName>RecreatedClusters</RecreatedClusterListName>
         <RecreatedVertexListName>RecreatedVertices</RecreatedVertexListName>
@@ -107,7 +105,7 @@
 	<SelectRecoHits>true</SelectRecoHits>
     </algorithm>
 
-<!--Hierarchy Monitoring Algorithm for visulaization-->
+<!--Hierarchy Monitoring Algorithm for visulaization
     <algorithm type = "LArHierarchyMonitoring">
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <PfoListName>RecreatedPfos</PfoListName>
@@ -123,7 +121,7 @@
         <MinCompleteness>0.1</MinCompleteness>
         <MinMatchCompleteness>0.1</MinMatchCompleteness>
     </algorithm>
-
+    -->
 <!-- Use old single neutrino event validation
     <algorithm type = "LArNeutrinoEventValidation">
         <CaloHitListName>CaloHitList2D</CaloHitListName>

--- a/settings/PandoraSettings_LArRecoND_ThreeD.xml
+++ b/settings/PandoraSettings_LArRecoND_ThreeD.xml
@@ -23,7 +23,7 @@
 
     <algorithm type = "LArMasterThreeD">
         <CRSettingsFile>PandoraSettings_Cosmic_Standard.xml</CRSettingsFile>
-        <NuSettingsFile>PandoraSettings_Neutrino_ThreeD.xml</NuSettingsFile>
+        <NuSettingsFile>PandoraSettings_Neutrino_ThreeD_Cheated.xml</NuSettingsFile>
         <SlicingSettingsFile>PandoraSettings_Slicing_ThreeD.xml</SlicingSettingsFile>
         <StitchingTools>
             <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>true</ThreeDStitchingMode></tool>
@@ -36,6 +36,8 @@
             <tool type = "LArSimpleNeutrinoId"/>
         </SliceIdTools>
         <InputHitListName>Input</InputHitListName>
+        <InputMCParticleListName>Input</InputMCParticleListName>
+        <PassMCParticlesToWorkerInstances>true</PassMCParticlesToWorkerInstances>
         <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>
         <RecreatedClusterListName>RecreatedClusters</RecreatedClusterListName>
         <RecreatedVertexListName>RecreatedVertices</RecreatedVertexListName>
@@ -103,6 +105,23 @@
         <MinRecoGoodViews>2</MinRecoGoodViews>
         <RemoveRecoNeutrons>true</RemoveRecoNeutrons>
 	<SelectRecoHits>true</SelectRecoHits>
+    </algorithm>
+
+<!--Hierarchy Monitoring Algorithm for visulaization-->
+    <algorithm type = "LArHierarchyMonitoring">
+        <CaloHitListName>CaloHitList2D</CaloHitListName>
+        <PfoListName>RecreatedPfos</PfoListName>
+        <VisualizeMC>true</VisualizeMC>
+        <VisualizeReco>true</VisualizeReco>
+        <VisualizeDistinct>true</VisualizeDistinct>
+        <PerformMatching>true</PerformMatching>
+        <CollectionOnly>false</CollectionOnly>
+        <FoldToPrimaries>true</FoldToPrimaries>
+        <FoldToLeadingShowers>false</FoldToLeadingShowers>
+        <FoldDynamic>false</FoldDynamic>
+        <MinPurity>0.5</MinPurity>
+        <MinCompleteness>0.1</MinCompleteness>
+        <MinMatchCompleteness>0.1</MinMatchCompleteness>
     </algorithm>
 
 <!-- Use old single neutrino event validation

--- a/settings/PandoraSettings_Neutrino_ThreeD_Cheated.xml
+++ b/settings/PandoraSettings_Neutrino_ThreeD_Cheated.xml
@@ -1,6 +1,6 @@
 <pandora>
     <!-- GLOBAL SETTINGS -->
-    <IsMonitoringEnabled>true</IsMonitoringEnabled>
+    <IsMonitoringEnabled>false</IsMonitoringEnabled>
     <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
     <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
 

--- a/settings/PandoraSettings_Neutrino_ThreeD_Cheated.xml
+++ b/settings/PandoraSettings_Neutrino_ThreeD_Cheated.xml
@@ -24,7 +24,7 @@
     <!-- 2D neutrino reconstruction, U View -->
     <algorithm type = "LArClusteringParent">
         <algorithm type = "LArCheatingClusterCreation" description = "ClusterFormation">
-            <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+            <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
             <MCParticleListName>Input</MCParticleListName>
         </algorithm>
         <InputCaloHitListName>CaloHitListU</InputCaloHitListName>
@@ -36,7 +36,7 @@
     <!-- 2D neutrino reconstruction, V View -->
     <algorithm type = "LArClusteringParent">
         <algorithm type = "LArCheatingClusterCreation" description = "ClusterFormation">
-            <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+            <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
             <MCParticleListName>Input</MCParticleListName>
         </algorithm>
         <InputCaloHitListName>CaloHitListV</InputCaloHitListName>
@@ -48,7 +48,7 @@
     <!-- 2D neutrino reconstruction, W View -->
     <algorithm type = "LArClusteringParent">
         <algorithm type = "LArCheatingClusterCreation" description = "ClusterFormation">
-            <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+            <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
             <MCParticleListName>Input</MCParticleListName>
         </algorithm>
         <InputCaloHitListName>CaloHitListW</InputCaloHitListName>

--- a/settings/PandoraSettings_Neutrino_ThreeD_Cheated.xml
+++ b/settings/PandoraSettings_Neutrino_ThreeD_Cheated.xml
@@ -1,6 +1,6 @@
 <pandora>
     <!-- GLOBAL SETTINGS -->
-    <IsMonitoringEnabled>false</IsMonitoringEnabled>
+    <IsMonitoringEnabled>true</IsMonitoringEnabled>
     <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
     <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
 
@@ -60,7 +60,7 @@
     <!-- 3D neutrino reconstruction -->
     <algorithm type = "LArClusteringParent">
         <algorithm type = "LArCheatingClusterCreation" description = "ClusterFormation">
-            <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+            <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
             <MCParticleListName>Input</MCParticleListName>
         </algorithm>
         <InputCaloHitListName>CaloHitList3D</InputCaloHitListName>
@@ -79,19 +79,19 @@
         <OutputPfoListName>NParticles3D</OutputPfoListName>
         <AddVertices>false</AddVertices>
         <MCParticleListName>Input</MCParticleListName>
-        <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+        <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
     </algorithm>
 
     <!-- 3D neutrino event hierarchy -->
     <algorithm type = "LArCheatingNeutrinoCreation">
-        <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+        <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
         <MCParticleListName>Input</MCParticleListName>
         <NeutrinoPfoListName>NeutrinoParticles3D</NeutrinoPfoListName>
         <VertexListName>NVertices</VertexListName>
         <DaughterPfoListNames>NParticles3D</DaughterPfoListNames>
     </algorithm>
     <algorithm type = "LArCheatingNeutrinoDaughterVertices">
-        <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+        <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
         <MCParticleListName>Input</MCParticleListName>
         <NeutrinoPfoListName>NeutrinoParticles3D</NeutrinoPfoListName>
         <OutputVertexListName>NDaughterVertices3D</OutputVertexListName>


### PR DESCRIPTION
This pull request changes a setting in the settings/PandoraSettings_Neutrino_ThreeD_Cheated.xml file to make CollapseToPrimaryMCParticles to be true. When running the cheated workflow, showers were being split up heavily, and this feature folds all of their hits into the primary particle. Currently a work in progress.