### PR TITLE
Set Collapse to Primary MC Particles to true in Cheated Neutrino XML (WIP)

### DIFF
--- a/settings/PandoraSettings_Neutrino_ThreeD_Cheated.xml
+++ b/settings/PandoraSettings_Neutrino_ThreeD_Cheated.xml
@@ -24,7 +24,7 @@
     <!-- 2D neutrino reconstruction, U View -->
     <algorithm type = "LArClusteringParent">
         <algorithm type = "LArCheatingClusterCreation" description = "ClusterFormation">
-            <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+            <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
             <MCParticleListName>Input</MCParticleListName>
         </algorithm>
         <InputCaloHitListName>CaloHitListU</InputCaloHitListName>
@@ -36,7 +36,7 @@
     <!-- 2D neutrino reconstruction, V View -->
     <algorithm type = "LArClusteringParent">
         <algorithm type = "LArCheatingClusterCreation" description = "ClusterFormation">
-            <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+            <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
             <MCParticleListName>Input</MCParticleListName>
         </algorithm>
         <InputCaloHitListName>CaloHitListV</InputCaloHitListName>
@@ -48,7 +48,7 @@
     <!-- 2D neutrino reconstruction, W View -->
     <algorithm type = "LArClusteringParent">
         <algorithm type = "LArCheatingClusterCreation" description = "ClusterFormation">
-            <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+            <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
             <MCParticleListName>Input</MCParticleListName>
         </algorithm>
         <InputCaloHitListName>CaloHitListW</InputCaloHitListName>
@@ -60,7 +60,7 @@
     <!-- 3D neutrino reconstruction -->
     <algorithm type = "LArClusteringParent">
         <algorithm type = "LArCheatingClusterCreation" description = "ClusterFormation">
-            <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+            <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
             <MCParticleListName>Input</MCParticleListName>
         </algorithm>
         <InputCaloHitListName>CaloHitList3D</InputCaloHitListName>
@@ -79,19 +79,19 @@
         <OutputPfoListName>NParticles3D</OutputPfoListName>
         <AddVertices>false</AddVertices>
         <MCParticleListName>Input</MCParticleListName>
-        <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+        <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
     </algorithm>
 
     <!-- 3D neutrino event hierarchy -->
     <algorithm type = "LArCheatingNeutrinoCreation">
-        <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+        <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
         <MCParticleListName>Input</MCParticleListName>
         <NeutrinoPfoListName>NeutrinoParticles3D</NeutrinoPfoListName>
         <VertexListName>NVertices</VertexListName>
         <DaughterPfoListNames>NParticles3D</DaughterPfoListNames>
     </algorithm>
     <algorithm type = "LArCheatingNeutrinoDaughterVertices">
-        <CollapseToPrimaryMCParticles>false</CollapseToPrimaryMCParticles>
+        <CollapseToPrimaryMCParticles>true</CollapseToPrimaryMCParticles>
         <MCParticleListName>Input</MCParticleListName>
         <NeutrinoPfoListName>NeutrinoParticles3D</NeutrinoPfoListName>
         <OutputVertexListName>NDaughterVertices3D</OutputVertexListName>


### PR DESCRIPTION
This pull request changes a setting the settings/PandoraSettings_Neutrino_ThreeD_Cheated.xml file and sets every instance of CollapseToPrimaryMCParticles to true. This assigns all hits to the primary particle they descended from. 